### PR TITLE
upgraded to latest psutil

### DIFF
--- a/requirements_py38.txt
+++ b/requirements_py38.txt
@@ -4,7 +4,7 @@ h5py==2.10.0
 matplotlib==3.3.4
 numpy==1.19.5
 pyyaml==5.3.1
-psutil==5.6.6
+psutil==5.8.0
 scipy==1.5.4
 scikit-learn
 jinja2==2.11.3


### PR DESCRIPTION
Upgraded psutil, because 5.6.6 produces the following issue on Python 3.8.5:

```
ERROR: Command errored out with exit status 1: /datadrive/big-ann-benchmarks/venv/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-zs6kc4m5/psutil_b10f38f13f914f6ca5f98e41bc4368e3/setup.py'"'"'; __file__='"'"'/tmp/pip-install-zs6kc4m5/psutil_b10f38f13f914f6ca5f98e41bc4368e3/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-w4uypm8v/install-record.txt --single-version-externally-managed --compile --install-headers /datadrive/big-ann-benchmarks/venv/include/site/python3.8/psutil Check the logs for full command output.
```