### PR TITLE
Range search fix and broken Docker build fix, for the Faiss baseline

### DIFF
--- a/benchmark/algorithms/faiss_t3.py
+++ b/benchmark/algorithms/faiss_t3.py
@@ -256,6 +256,9 @@ class IndexQuantizerOnGPU:
         return D, I
 
     def range_search(self, x, radius):
+
+        x = x.astype( np.float32 ) #GW
+
         bs = self.search_bs
         if self.vec_transform:
             x = self.vec_transform(x)

--- a/t3/faiss_t3/Dockerfile
+++ b/t3/faiss_t3/Dockerfile
@@ -6,7 +6,7 @@ ARG PATH="/root/miniconda3/bin:${PATH}"
 
 # CONDA
 
-RUN apt-get update  && apt-get install -y wget # libopenblas-base libopenblas-dev libpython3-dev swig python3-dev libssl-dev wget git
+RUN apt-get update  && apt-get install -y wget build-essential git 
 
 RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
@@ -14,14 +14,12 @@ RUN wget \
     && bash Miniconda3-latest-Linux-x86_64.sh -b \
     && rm -f Miniconda3-latest-Linux-x86_64.sh \
     && conda --version \
-    && conda install -c pytorch faiss-gpu cudatoolkit=11.0
+    && conda install -c pytorch python=3.6.9 faiss-gpu cudatoolkit=11.0
 
 RUN conda --version && which conda && which python && which pip3
 
 # BIGANN
 
-RUN apt-get update
-RUN apt-get install -y python3-numpy python3-scipy python3-pip build-essential git
 RUN pip3 install -U pip
 
 WORKDIR /home/app


### PR DESCRIPTION
This PR fixes a few issues with the baseline:

* The SSNPP NP.UINT8 data now requires an explicit cast to NP.FLOAT32 before presenting to FAISS range search library call.  It's a bit puzzling why this broke now since SSNPP was working before (perhaps there was explicit/implicit coercion in code elsewhere that was backed-out recently ? ). Anyway, an explicit cast now appears to fix the issue.
* The FAISS baseline docker build needed updating.  It looks like the latest miniconda (the previous Dockerfile downloaded the latest) installs the latest stable python (3.9) and that version now breaks other packages that need to be installed - ie, conda "resolution" fails.  I locked it to python=3.6.9 and that seems to the trick.  I verified on SSNPP, DEEP-1B, and BIGANN-1B.