### PR TITLE
Store individual search times and extend CSV export capability for search times and power metrics.

### DIFF
--- a/benchmark/plotting/metrics.py
+++ b/benchmark/plotting/metrics.py
@@ -166,7 +166,7 @@ all_metrics = {
     },
     "search_times": {
         "description": "List of consecutive search times for the same run parameter",
-        "function": lambda true_nn, run_nn, metrics, run_attrs: run_attrs["search_times"], 
+        "function": lambda true_nn, run_nn, metrics, run_attrs: run_attrs.get("search_times",[]), 
         "worst": float("inf")
     },
 

--- a/benchmark/plotting/metrics.py
+++ b/benchmark/plotting/metrics.py
@@ -163,6 +163,11 @@ all_metrics = {
         "description": "Mean latency across queries",
         "function": lambda true_nn, run_nn, metrics, run_attrs: mean_latency(run_attrs),  
         "worst": float("inf")
-    }
+    },
+    "search_times": {
+        "description": "List of consecutive search times for the same run parameter",
+        "function": lambda true_nn, run_nn, metrics, run_attrs: run_attrs["search_times"], 
+        "worst": float("inf")
+    },
 
 }

--- a/benchmark/plotting/utils.py
+++ b/benchmark/plotting/utils.py
@@ -67,7 +67,8 @@ def compute_metrics(true_nn, res, metric_1, metric_2,
 
     return all_results
 
-def compute_metrics_all_runs(dataset, res, recompute=False, sensor_metrics=False):
+def compute_metrics_all_runs(dataset, res, recompute=False, \
+        sensor_metrics=False, search_times=False):
     try:
         true_nn = dataset.get_groundtruth()
     except:
@@ -108,7 +109,9 @@ def compute_metrics_all_runs(dataset, res, recompute=False, sensor_metrics=False
             if search_type == "knn" and name == "ap" or\
                 search_type == "range" and name == "k-nn":
                 continue
-            if not sensor_metrics and name=="wspq": #don't process sensor_metrics by default
+            if not sensor_metrics and name=="wspq": #don't process power sensor_metrics by default
+                continue
+            if not search_times and name=="search_times": #don't process search_times by default
                 continue
             v = metric["function"](true_nn, run_nn, metrics_cache, properties)
             run_result[name] = v

--- a/benchmark/results.py
+++ b/benchmark/results.py
@@ -41,6 +41,7 @@ def store_results(dataset, count, definition, query_arguments,
         os.makedirs(head)
     f = h5py.File(fn, 'w')
     for k, v in attrs.items():
+        print("kv=",k,v)
         f.attrs[k] = v
     if search_type == "knn":
         neighbors = f.create_dataset('neighbors', (len(results), count), 'i')

--- a/benchmark/results.py
+++ b/benchmark/results.py
@@ -41,7 +41,6 @@ def store_results(dataset, count, definition, query_arguments,
         os.makedirs(head)
     f = h5py.File(fn, 'w')
     for k, v in attrs.items():
-        print("kv=",k,v)
         f.attrs[k] = v
     if search_type == "knn":
         neighbors = f.create_dataset('neighbors', (len(results), count), 'i')

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -25,6 +25,7 @@ def run_individual_query(algo, X, distance, count, run_count, search_type):
     for i in range(run_count):
         print('Run %d/%d...' % (i + 1, run_count))
 
+        search_times = []
         start = time.time()
         if search_type == "knn":
             algo.query(X, count)
@@ -38,6 +39,7 @@ def run_individual_query(algo, X, distance, count, run_count, search_type):
 
         search_time = total
         best_search_time = min(best_search_time, search_time)
+        search_times.append( search_time )
 
     attrs = {
         "best_search_time": best_search_time,
@@ -45,7 +47,8 @@ def run_individual_query(algo, X, distance, count, run_count, search_type):
         "run_count": run_count,
         "distance": distance,
         "type": search_type,
-        "count": int(count)
+        "count": int(count),
+        "search_times": search_times
     }
     additional = algo.get_additional()
     for k in additional:

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -131,7 +131,6 @@ function""" % (definition.module, definition.constructor, definition.arguments)
                 descriptor["index_size"] = index_size
                 descriptor["algo"] = definition.algorithm
                 descriptor["dataset"] = dataset
-                print("descriptor store", descriptor) 
                 if power_capture.enabled():
                     power_stats = power_capture.run(algo, X, distance, count,
                                                     run_count, search_type, descriptor)

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -22,10 +22,10 @@ from benchmark.t3.helper import t3_create_container
 
 def run_individual_query(algo, X, distance, count, run_count, search_type):
     best_search_time = float('inf')
+    search_times = []
     for i in range(run_count):
         print('Run %d/%d...' % (i + 1, run_count))
 
-        search_times = []
         start = time.time()
         if search_type == "knn":
             algo.query(X, count)
@@ -131,7 +131,7 @@ function""" % (definition.module, definition.constructor, definition.arguments)
                 descriptor["index_size"] = index_size
                 descriptor["algo"] = definition.algorithm
                 descriptor["dataset"] = dataset
-                
+                print("descriptor store", descriptor) 
                 if power_capture.enabled():
                     power_stats = power_capture.run(algo, X, distance, count,
                                                     run_count, search_type, descriptor)

--- a/data_export.py
+++ b/data_export.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
                     result['search_times'] = \
                         " ".join( [str(el) for el in result['search_times'] ] )
                 else:
-                    print("Warning: 'search_times' not avaalable.")
+                    print("Warning: 'search_times' not available.")
             cleaned.append(result)
         dfs.append(pd.DataFrame(cleaned))
     if len(dfs) > 0:

--- a/data_export.py
+++ b/data_export.py
@@ -34,7 +34,8 @@ if __name__ == "__main__":
         '--detect_caching',
         type=float,
         default=None,
-        help='Try to detect query response caching by analyzing search times.  Supply a percent threshold such as 0.3.')
+        metavar="THRESHOLD",
+        help='Try to detect query response caching by analyzing search times.  Supply a threshold betwee 0 and 1, such as 0.3.')
     args = parser.parse_args()
 
     if args.detect_caching!=None and not args.search_times:

--- a/data_export.py
+++ b/data_export.py
@@ -50,9 +50,7 @@ if __name__ == "__main__":
                 result['recall/ap'] = result['ap']
                 del result['ap']
             if args.sensors:
-                if 'wspq' in result:
-                    result['wspq'] = result['wspq']
-                else:
+                if 'wspq' not in result:
                     print('Warning: wspq sensor data not available.')
             if args.search_times:
                 if 'search_times' in result:


### PR DESCRIPTION
@maumueller @harsha-simhadri 

I could use a second pair of eyes on this PR.

This PR is primarily to support query response cache detection as a post process step.  

This PR introduces the following:
* Tracks and stores the list of individual search_times for each query run
* Allows export of the search_times list via new --search_times flag in data_export.py
* Allows export of (best) power metrics via new --sensors flag in data_export.py.  This has been missing from the main branch so I figured this PR was a good chance to fold it in. )

In general, the idea is to continue to be backward compatible with existing results h5py data stores that don't store search_times or power-related metrics.

All feedback is welcome.  Thanks!