### PR TITLE
Fix docker container return values

### DIFF
--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -305,18 +305,29 @@ def run_docker(definition, dataset, count, runs, timeout, rebuild,
     t.start()
 
     try:
-        exit_code = container.wait(timeout=timeout)
-
-        # Exit if exit code
-        if exit_code not in [0, None]:
-            logger.error(colors.color(container.logs().decode(), fg='red'))
-            logger.error('Child process for container %s raised exception %d' % (container.short_id, exit_code))
+        return_value = container.wait(timeout=timeout)
+        _handle_container_return_value(return_value, container, logger)
     except:
         logger.error('Container.wait for container %s failed with exception' % container.short_id)
         logger.error('Invoked with %s' % cmd)
         traceback.print_exc()
     finally:
         container.remove(force=True)
+        
+
+def _handle_container_return_value(return_value, container, logger):
+    base_msg = 'Child process for container %s' % (container.short_id)
+    if type(return_value) is dict: # The return value from container.wait changes from int to dict in docker 3.0.0
+        error_msg = return_value['Error']
+        exit_code = return_value['StatusCode']
+        msg = base_msg + 'returned exit code %d with message %s' %(exit_code, error_msg)
+    else: 
+        exit_code = return_value
+        msg = base_msg + 'returned exit code %d' % (exit_code)
+
+    if exit_code not in [0, None]:
+        logger.error(colors.color(container.logs().decode(), fg='red'))
+        logger.error(msg)
 
 
 def run_no_docker(definition, dataset, count, runs, timeout, rebuild,


### PR DESCRIPTION
Hello everyone,

I was executing diskann-t2 with random-xs as dataset and I received an error although the run seems to finish successful. 

```
Traceback (most recent call last):
  File "/home/ubuntu/big-ann-benchmarks/benchmark/runner.py", line 313, in run_docker
    logger.error('Child process for container %s raised exception %d' % (container.short_id, exit_code))
TypeError: %d format: a real number is required, not dict
```

I looked into the repository of ANN-Benchmarks and found a similar issue there (https://github.com/erikbern/ann-benchmarks/issues/282). Attached to that issue was a pull-request (https://github.com/erikbern/ann-benchmarks/pull/283) to fix the problem. 

I applied the changes in that pull-request to Big ANN-Benchmarks and it seems to fix the problem here too. Could please somebody review my changes, since all I did was copy the solution for the problem in ANN-Benchmarks and I'm not sure if I violated any coding style guidelines of this repository.

For testing I simply executed 

`python run.py --algorithm diskann-t2 --dataset random-xs`
and
`python run.py --algorithm faiss-t21 --dataset random-xs`

and they worked without a flaw as far as I can tell.