### PR TITLE
competition 2 BaseANN changes

### DIFF
--- a/benchmark/algorithms/base.py
+++ b/benchmark/algorithms/base.py
@@ -47,11 +47,11 @@ class BaseANN(object):
         """
         raise NotImplementedError()
 
-    def query(self, X, k):
+    def query(self, X, k, meta_filter=[]):
         """Carry out a batch query for k-NN of query set X."""
         raise NotImplementedError()
 
-    def range_query(self, X, radius):
+    def range_query(self, X, radius, meta_filter=[]):
         """
         Carry out a batch query for range search with
         radius.


### PR DESCRIPTION

This is a draft PR to get ideas/feedback around possible changes to BaseANN for the second competition.

Assumptions:
* each object in a dataset could have a dense vector or a sparse vector (or both)
* each object could also have a set of scalar filters associated with it
* *range_query()* won't change for the second competition (?)

Possible Approaches:
* augment the *query()* with additional parameters called **meta_filter** and **sparse_vector** which default to None.  This assumes the *query()* **X**  parameter is still a dense vector
* create a new virtual method called *hybrid_query()* which exposes a three parameters **dense_vector**, **sparse_vector** and **meta_filter**.  

( @harsha-simhadri had asked me to kick-start this, but if anything has already been done here I'm happy close this PR )