### PR TITLE
Ingberam/linscan

### DIFF
--- a/algos-2023.yaml
+++ b/algos-2023.yaml
@@ -94,7 +94,7 @@ sparse-small:
     linscan:
       docker-tag: billion-scale-benchmark-linscan
       module: neurips_2023.sparse.linscan 
-      constructor: SparseIndex
+      constructor: Linscan
       base-args: ["@metric"]
       run-groups:
         base:

--- a/algos-2023.yaml
+++ b/algos-2023.yaml
@@ -101,7 +101,7 @@ sparse-small:
           args: |
             [{}]
           query-args: |
-            [{"alpha":0.5}]
+            [{"budget":1},{"budget":0.5},{"budget":0.3}]
 msturing-1M:
     diskann-t2:
       docker-tag: billion-scale-benchmark-diskann

--- a/algos-2023.yaml
+++ b/algos-2023.yaml
@@ -101,7 +101,7 @@ sparse-small:
           args: |
             [{}]
           query-args: |
-            [{"budget":1},{"budget":0.5},{"budget":0.3}]
+            [{"budget":1},{"budget":0.5},{"budget":0.3},{"budget":0.2},{"budget":0.15},{"budget":0.1},{"budget":0.075},{"budget":0.05}]
 msturing-1M:
     diskann-t2:
       docker-tag: billion-scale-benchmark-diskann

--- a/install/Dockerfile.linscan
+++ b/install/Dockerfile.linscan
@@ -20,3 +20,5 @@ RUN pip install ./target/wheels/*.whl
 
 # verify that the build worked
 RUN python3 -c 'import pylinscan; print(pylinscan.LinscanIndex());'
+
+WORKDIR ..

--- a/install/Dockerfile.linscan
+++ b/install/Dockerfile.linscan
@@ -1,7 +1,22 @@
 FROM billion-scale-benchmark
 
-RUN apt-get update
-RUN apt-get install -y wget git cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev python3 python3-setuptools python3-pip
+RUN apt-get install -y curl
 
-RUN pip3 install scipy tqdm
+# install rust + build tools
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN git clone --single-branch --branch main https://github.com/pinecone-io/research-bigann-linscan
+WORKDIR research-bigann-linscan/
+RUN pip install tqdm
 
+# install maturin (build tool for rust-python)
+RUN pip install maturin
+
+# build a whl file
+RUN maturin build -r
+
+# pip install the correct wheel (different architectures will produce .whl files with different names)
+RUN pip install ./target/wheels/*.whl
+
+# verify that the build worked
+RUN python3 -c 'import pylinscan; print(pylinscan.LinscanIndex());'

--- a/install/Dockerfile.linscan
+++ b/install/Dockerfile.linscan
@@ -7,7 +7,6 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN git clone --single-branch --branch main https://github.com/pinecone-io/research-bigann-linscan
 WORKDIR research-bigann-linscan/
-RUN pip install tqdm
 
 # install maturin (build tool for rust-python)
 RUN pip install maturin

--- a/neurips-2023/sparse/eval_sparse.py
+++ b/neurips-2023/sparse/eval_sparse.py
@@ -1,0 +1,67 @@
+import argparse
+
+import time
+import numpy as np
+from benchmark.datasets import DATASETS
+
+
+from linscan import Linscan
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    def aa(*args, **kwargs):
+        group.add_argument(*args, **kwargs)
+
+    group = parser.add_argument_group('files')
+    aa('--dataset_name', required=True, help="Sparse dataset version, must be in sparse-{'small', '1M', 'full'}.")
+
+    group = parser.add_argument_group('Computation options')
+    aa('--budgets',required=True, help="budgets for linscan's score computation part in ms")
+    aa('--k', default=10, type=int, help="number of nearest kNN neighbors to search")
+
+    args = parser.parse_args()
+
+    print("args:", args)
+    print('k: ', args.k)
+
+    ds = DATASETS[args.dataset_name]()
+
+    ds.prepare()
+
+    I_gt,D_gt = ds.get_groundtruth()
+
+    data = ds.get_dataset()
+    queries = ds.get_queries()
+
+    print('data:', data.shape)
+    print('queries:', queries.shape)
+
+    k = args.k
+    nq = queries.shape[0]
+
+    index = Linscan(metric="ip", index_params={})
+    index.fit(args.dataset_name)
+
+    budgets = [float(b) for b in args.budgets.split(',')]
+    print(budgets)
+
+    results = []
+    for b in budgets:
+        print('evaluating', nq, 'queries:')
+        start = time.time()
+        index.set_query_arguments({"budget": b})
+        index.query(queries, k)
+        I = index.get_results()
+        end = time.time()
+        elapsed = end - start
+        print(f'Elapsed {elapsed}s for {nq} queries ({nq / elapsed} QPS) ')
+
+        # compute recall:
+        recall = np.mean([len(set(I_gt[i,:]).intersection(I[i,:]))/k for i in range(ds.nq)])
+
+        print('recall:', recall)
+        results.append(f'Results: {b}, {recall}, {nq / elapsed}')
+
+    for r in results:
+        print(r)

--- a/neurips-2023/sparse/eval_sparse.py
+++ b/neurips-2023/sparse/eval_sparse.py
@@ -31,10 +31,9 @@ if __name__ == "__main__":
 
     I_gt,D_gt = ds.get_groundtruth()
 
-    data = ds.get_dataset()
     queries = ds.get_queries()
 
-    print('data:', data.shape)
+    print('# vectors in dataset:', ds.nb)
     print('queries:', queries.shape)
 
     k = args.k

--- a/neurips-2023/sparse/linscan.py
+++ b/neurips-2023/sparse/linscan.py
@@ -10,6 +10,8 @@ import pylinscan
 # algorithm details: https://arxiv.org/abs/2301.10622
 # code: https://github.com/pinecone-io/research-bigann-linscan
 
+# Build parameters: none
+# Query parameters: budget (in ms) for computing all the scores
 class Linscan(BaseANN):
     def __init__(self, metric, index_params):
         print(metric, index_params)

--- a/neurips-2023/sparse/spmat.py
+++ b/neurips-2023/sparse/spmat.py
@@ -72,13 +72,12 @@ class SparseIndex(BaseANN):
         results.sort(reverse=True)
         return [(res.indices[b], a) for a, b in results]
 
-    def query(self, X, k):  # single query, assumes q is a row vector
+    def query(self, X, k):  # Carry out a batch query for k-NN of query set X.
+
         nq = X.shape[0]
         self.I = -np.ones((nq, k), dtype='int32')
         self.queries = X
 
-        with ThreadPool() as pool:
-            list(pool.imap(self._process_single_row, range(nq)))
 
     def get_results(self):
         return self.I

--- a/neurips-2023/sparse/spmat.py
+++ b/neurips-2023/sparse/spmat.py
@@ -34,7 +34,7 @@ def largest_elements(x, a):
 # 2. query:
 #    - k (# of neighbors),
 #    - alpha (fraction of the sum of the vector elements to maintain. alpha=1 is exact search).
-class SparseIndex(BaseANN):
+class SparseMatMul(BaseANN):
     def __init__(self, metric, index_params):
         print(metric, index_params)
         self.name = "spmat"

--- a/neurips-2023/sparse/spmat.py
+++ b/neurips-2023/sparse/spmat.py
@@ -6,7 +6,7 @@ import numpy as np
 from multiprocessing.pool import ThreadPool
 
 from benchmark.algorithms.base import BaseANN
-from benchmark.datasets import DATASETS, download_accelerated
+from benchmark.datasets import DATASETS
 
 # given a vector x, returns another vector with the minimal number of largest elements of x,
 # s.t. their sum is at most a times the sum of the elements in x.
@@ -28,16 +28,16 @@ def largest_elements(x, a):
     return csr_matrix((new_data, new_ind, [0, n_elements]), shape=x.shape)
 
 
-# a basic sparse index.
+# a basic sparse index based on sparse matrix multiplication
 # methods:
 # 1. init: from a csr matrix of data.
-# 2. query a singe vector, with parameters:
+# 2. query:
 #    - k (# of neighbors),
-#    - alpha (fraction of the sum of the vector to maintain. alpha=1 is exact search).
+#    - alpha (fraction of the sum of the vector elements to maintain. alpha=1 is exact search).
 class SparseIndex(BaseANN):
     def __init__(self, metric, index_params):
         print(metric, index_params)
-        self.name = "linsparse"
+        self.name = "spmat"
     
     def fit(self, dataset):
         self.ds = DATASETS[dataset]()


### PR DESCRIPTION
this PR adds the efficient linscan implementation (in rust with python bindings), with a dockerfile.

The dockerfile builds on top of Harsha's latest dockerfile with python 3.10, so this PR is on top of `harshasi/framework`.

Status:
`python install.py --algorithm linscan` works fine and builds the docker image.
`python3 create_dataset.py --dataset <dataset>` works fine for `dataset` in `{sparse-small, sparse-1M, sparse-full`.
 
I am still having some trouble running the algorithm with run.py  (getting some errors related to urllib incompatibility with docker in python). Does anyone have any ideas?

Regardless, there is a file called `eval_sparse.py` which evaluates the new linscan with different parameters (but the python .whl file needs to be built manually).

Sample run:
```
> python eval_sparse.py --dataset_name sparse-small --budgets 0.02,0.04,0.07,0.1,0.2,0.3,0.5
args: Namespace(dataset_name='sparse-small', budgets='0.02,0.04,0.07,0.1,0.2,0.3,0.5', k=10)
k:  10
unzipped version of file data/sparse/queries.dev.csr.gz already exists
file data/sparse/base_small.dev.gt already exists
unzipped version of file data/sparse/base_small.csr.gz already exists
data: (100000, 30109)
queries: (6980, 30109)
ip {}
Initializing a new LinscanIndex.
[0.02, 0.04, 0.07, 0.1, 0.2, 0.3, 0.5]
evaluating 6980 queries:
Elapsed 0.2191629409790039s for 6980 queries (31848.450147731375 QPS) 
recall: 0.6655873925501433
evaluating 6980 queries:
Elapsed 0.23474621772766113s for 6980 queries (29734.238393982512 QPS) 
recall: 0.8006160458452722
evaluating 6980 queries:
Elapsed 0.26549291610717773s for 6980 queries (26290.72030374709 QPS) 
recall: 0.8795558739255016
evaluating 6980 queries:
Elapsed 0.28344106674194336s for 6980 queries (24625.930463191788 QPS) 
recall: 0.9225214899713469
evaluating 6980 queries:
Elapsed 0.33168601989746094s for 6980 queries (21043.998182853265 QPS) 
recall: 0.9787249283667622
evaluating 6980 queries:
Elapsed 0.36275196075439453s for 6980 queries (19241.798129730552 QPS) 
recall: 0.9928796561604585
evaluating 6980 queries:
Elapsed 0.37570810317993164s for 6980 queries (18578.252480908523 QPS) 
recall: 0.9970343839541547
Results: 0.02, 0.6655873925501433, 31848.450147731375
Results: 0.04, 0.8006160458452722, 29734.238393982512
Results: 0.07, 0.8795558739255016, 26290.72030374709
Results: 0.1, 0.9225214899713469, 24625.930463191788
Results: 0.2, 0.9787249283667622, 21043.998182853265
Results: 0.3, 0.9928796561604585, 19241.798129730552
Results: 0.5, 0.9970343839541547, 18578.252480908523

```



PS the old sparse index (python only, based on sparse matrix multiplication) was renamed to `SparseMatMul`. 
