### PR TITLE
refine sparse params

### DIFF
--- a/neurips23/sparse/linscan/config.yaml
+++ b/neurips23/sparse/linscan/config.yaml
@@ -33,5 +33,5 @@ sparse-full:
           args: |
             [{}]
           query-args: |
-            [{"budget":5},{"budget":10},{"budget":20},{"budget":30},{"budget":40},{"budget":50},{"budget":60},{"budget":90},{"budget":150}]
+            [{"budget":5},{"budget":15},{"budget":35},{"budget":50},{"budget":52.5},{"budget":55},{"budget":57.5},{"budget":60},{"budget":90},{"budget":500}]
           


### PR DESCRIPTION
@harsha-simhadri this PR has some refined parameters. On my VM (8CPU/16GB ram) I was able to get to 102QPS with R@10 of 0.901. See below. Would you mind trying on the Azure VM?
Thanks


```
...
linscan,linscan,sparse-full,10,125.97474680730924,0.0,1000000.0,9724612.0,77194.9318927765,0,0,sparse,0.8615902578796562
linscan,linscan,sparse-full,10,102.06087468807476,0.0,1000000.0,9724612.0,95282.46774016984,0,0,sparse,0.9016189111747851
linscan,linscan,sparse-full,10,98.965607751189,0.0,1000000.0,9724612.0,98262.54009826122,0,0,sparse,0.9065186246418339
linscan,linscan,sparse-full,10,96.04432978052625,0.0,1000000.0,9724612.0,101251.28700696855,0,0,sparse,0.9106160458452722
...
```