### PR TITLE
Fixed running install.py on a full track

### DIFF
--- a/install.py
+++ b/install.py
@@ -66,8 +66,8 @@ if __name__ == "__main__":
         if args.algorithm: # build a specific algorithm
             algos = [args.algorithm] 
         else: # build all algorithms in the track with Dockerfiles.
-            algos = filter(lambda entry : os.path.exists(neurips23.common.dockerfile_path(track, entry)),
-                            os.listdir(neurips23.common.track_path(track)))
+            algos = list(filter(lambda entry : os.path.exists(neurips23.common.dockerfile_path(track, entry)),
+                            os.listdir(neurips23.common.track_path(track))))
         tags = [neurips23.common.docker_tag(track, algo) for algo in algos]
         dockerfiles = [neurips23.common.dockerfile_path(track, algo) for algo in algos]
     else: # NeurIPS'21


### PR DESCRIPTION
Currently, `install.py` does not build anything but the base dockerfile when you run it without specifying an algorithm, due to a bug on line 69.

The `filter` builtin actually returns an iterator over the results of a filtering of the input, not a collection containing them. Because iterators in python do not reset, the list comprehension using `algos` in line 72 of `install.py` has no elements after they're all consumed on the previous line, so `dockerfiles` is empty.

Demonstration of this idea:
```
>>> f = filter(lambda x: x % 2 == 0, list(range(50)))
>>> type(f)
<class 'filter'>
>>> x = [n for n in f]
>>> x
[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48]
>>> y = [n for n in f]
>>> y
[]
```
`zip(tags, dockerfiles)` on line 94 has as many elements as its shortest argument, and therefore does nothing when you iterate over it in this case. 

Building a list with the iterator created by `filter` solves this problem, because lists create a new iterator every time you try to iterate over them.