### PR TITLE
Bump docker to 7.1.0 in requirements_py3.10.txt

### DIFF
--- a/requirements_py3.10.txt
+++ b/requirements_py3.10.txt
@@ -1,5 +1,5 @@
 ansicolors==1.1.8
-docker==6.1.2
+docker==7.1.0
 h5py==3.10.0
 matplotlib==3.3.4
 numpy==1.24.2


### PR DESCRIPTION
While following the steps listed in https://github.com/harsha-simhadri/big-ann-benchmarks/tree/main/neurips23#getting_started, got the following error.

```
python3 run.py --neurips23track streaming --algorithm diskann --dataset random-xs --runbook_path neurips23/streaming/simple_runbook.yaml
Preparing datasets with 10000 random points and 1000 queries.
Computing groundtruth
2024-07-25 22:01:23,790 - annb - INFO - running only diskann
Traceback (most recent call last):
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/requests/adapters.py", line 633, in send
    conn = self.get_connection_with_tls_context(
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/requests/adapters.py", line 489, in get_connection_with_tls_context
    conn = self.poolmanager.connection_from_host(
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/urllib3/poolmanager.py", line 303, in connection_from_host
    return self.connection_from_context(request_context)
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/urllib3/poolmanager.py", line 325, in connection_from_context
    raise URLSchemeUnknown(scheme)
urllib3.exceptions.URLSchemeUnknown: Not supported URL scheme http+docker

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/docker/api/client.py", line 214, in _retrieve_server_version
    return self.version(api_version=False)["ApiVersion"]
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/docker/api/daemon.py", line 181, in version
    return self._result(self._get(url), json=True)
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/docker/utils/decorators.py", line 46, in inner
    return f(self, *args, **kwargs)
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/docker/api/client.py", line 237, in _get
    return self.get(url, **self._set_request_timeout(kwargs))
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/requests/adapters.py", line 637, in send
    raise InvalidURL(e, request=request)
requests.exceptions.InvalidURL: Not supported URL scheme http+docker

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/onurctirtir/big-ann-benchmarks/run.py", line 6, in <module>
    main()
  File "/home/onurctirtir/big-ann-benchmarks/benchmark/main.py", line 234, in main
    docker_client = docker.from_env()
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/docker/client.py", line 96, in from_env
    return cls(
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/docker/client.py", line 45, in __init__
    self.api = APIClient(*args, **kwargs)
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/docker/api/client.py", line 197, in __init__
    self._version = self._retrieve_server_version()
  File "/home/onurctirtir/.local/lib/python3.10/site-packages/docker/api/client.py", line 221, in _retrieve_server_version
    raise DockerException(
docker.errors.DockerException: Error while fetching server API version: Not supported URL scheme http+docker
```

Specifically this error
```
requests.exceptions.InvalidURL: Not supported URL scheme http+docker
```

Seems that https://github.com/docker/docker-py/pull/3257 fixed https://github.com/docker/docker-py/issues/3256 already and 7.1.0 is the earliest version that has this fix, hence bumping docker version.