### PR TITLE
Add Wikipedia-Cohere and MS MARCO Web Search Datasets

### DIFF
--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -498,6 +498,11 @@ class MSSPACEV1B(BillionScaleDatasetCompetitionFormat):
     def distance(self):
         return "euclidean"
 
+'''
+The base vectors of Wikipedia-Cohere consist of 35 million cohere embeddings of the title and text of Wikipedia English articles. 
+The 5000 query vectors consist of 5000 cohere embeddings of the title and text of Wikipedia simple articles.
+See https://huggingface.co/datasets/Cohere/wikipedia-22-12-en-embeddings?row=2 for more details.
+'''
 class WikipediaDataset(BillionScaleDatasetCompetitionFormat):
     def __init__(self, nb=35000000):
         self.nb = nb
@@ -537,6 +542,12 @@ class WikipediaDataset(BillionScaleDatasetCompetitionFormat):
     def distance(self):
         return "ip"
 
+'''
+The MSMarco Web Search dataset has 100,924,960 base vectors consisting of embeddings of web documents 
+from the ClueWeb22 document dataset, while its 9,374 queries correspond to web queries collected from 
+the Microsoft Bing search engine.
+See https://github.com/microsoft/MS-MARCO-Web-Search for more details.
+'''
 class MSMarcoWebSearchDataset(BillionScaleDatasetCompetitionFormat):
     def __init__(self, nb=101070374):
         self.nb = nb


### PR DESCRIPTION
This PR adds two new datasets to the benchmark suite. 

The first dataset is Wikipedia-Cohere, and its base vectors consist of 35 million [cohere embeddings](https://huggingface.co/datasets/Cohere/wikipedia-22-12-en-embeddings?row=2) of the title and text of Wikipedia English articles. The 5000 query vectors consist of 5000 [cohere embeddings](https://huggingface.co/datasets/Cohere/wikipedia-22-12-simple-embeddings) of the title and text of Wikipedia simple articles. The embeddings are licensed under an [Apache 2.0 license](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/apache-2.0.md), and we confirmed permission with the authors to host and contribute these datasets to Big ANN Benchmarks. Ground truth for the first 100K, 1M, and 35M vectors are provided.

The second dataset is [MS Marco Web Search](https://github.com/microsoft/MS-MARCO-Web-Search?tab=readme-ov-file). Its 100,924,960 base vectors consist of embeddings of web documents from the ClueWeb22 document dataset, while its 9,374 queries correspond to web queries collected from the Microsoft Bing search engine. The authors state that ["The MS MARCO Web Search are intended for non-commercial research purposes only to promote advancement in the field of artificial intelligence and related areas, and is made available free of charge without extending any license or other intellectual property rights."](https://github.com/microsoft/MS-MARCO-Web-Search?tab=readme-ov-file#terms-and-conditions) We confirmed permission with the authors to contribute these datasets. Ground truth for the first 1M, 10M, and 100M vectors are provided. 