### PR TITLE
Correctly generate dataset filename in DatasetCompetitionFormat

### DIFF
--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -177,6 +177,9 @@ class DatasetCompetitionFormat(Dataset):
 
     def get_dataset_fn(self):
         fn = os.path.join(self.basedir, self.ds_fn)
+        if self.nb != 10**9:
+            fn += '.crop_nb_%d' % self.nb
+
         if os.path.exists(fn):
             return fn
         else:


### PR DESCRIPTION
Since the way that BillionScaleDatasetCompetitionFormat and DatasetCompetitionFormat generates the dataset filenames differ, we got the following error during the benchmarks:

```sh
pip3 install -r requirements_py3.10.txt
> <everything is fine>

python3 create_dataset.py --dataset msturing-30M-clustered
> file data/MSTuring-30M-clustered/testQuery10K.fbin already exists
> file data/MSTuring-30M-clustered/clu_msturing30M_gt100 already exists
> file data/MSTuring-30M-clustered/30M-clustered64.fbin.crop_nb_29998994 already exists

python3 install.py --neurips23track streaming --algorithm diskann
> Install Status:
> {'neurips23-streaming-diskann': 'success'}

python3 run.py --neurips23track streaming --algorithm diskann --dataset msturing-30M-clustered --runbook_path neurips23/streaming/final_runbook.yaml
> file data/MSTuring-30M-clustered/testQuery10K.fbin already exists
> file data/MSTuring-30M-clustered/clu_msturing30M_gt100 already exists
> file data/MSTuring-30M-clustered/30M-clustered64.fbin.crop_nb_29998994 already exists
> 2024-08-16 01:49:40,940 - annb - INFO - running only diskann
> 2024-08-16 01:49:41,522 - annb - INFO - Order: [Definition(algorithm='diskann', constructor='diskann', module='neurips23.streaming.diskann.diskann-str', docker_tag='neurips23-streaming-diskann', docker_volumes=[], arguments=['euclidean', {'R': 50, 'L': 50, 'insert_threads': 16, 'consolidate_threads': 16}], query_argument_groups=[[{'Ls': 70, 'T': 16}]], disabled=False), Definition(algorithm='diskann', constructor='diskann', module='neurips23.streaming.diskann.diskann-str', docker_tag='neurips23-streaming-diskann', docker_volumes=[], arguments=['euclidean', {'R': 32, 'L': 50, 'insert_threads': 16, 'consolidate_threads': 16}], query_argument_groups=[[{'Ls': 70, 'T': 16}]], disabled=False), Definition(algorithm='diskann', constructor='diskann', module='neurips23.streaming.diskann.diskann-str', docker_tag='neurips23-streaming-diskann', docker_volumes=[], arguments=['euclidean', {'R': 32, 'L': 70, 'insert_threads': 16, 'consolidate_threads': 16}], query_argument_groups=[[{'Ls': 70, 'T': 16}]], disabled=False)]
> RW Namespace(dataset='msturing-30M-clustered', count=10, definitions='algos-2021.yaml', algorithm='diskann', docker_tag=None, list_algorithms=False, force=False, rebuild=False, runs=5, timeout=43200, max_n_algorithms=-1, power_capture='', t3=False, nodocker=False, upload_index=False, download_index=False, blob_prefix=None, sas_string=None, private_query=False, neurips23track='streaming', runbook_path='neurips23/streaming/final_runbook.yaml')
> Setting container wait timeout to 3600 seconds
> 2024-08-16 01:49:42,325 - annb.271fd74032af - INFO - Created container 271fd74032af: CPU limit 0-19, mem limit 21487328000, timeout 3600, command ['--dataset', 'msturing-30M-clustered', '--algorithm', 'diskann', '--module', 'neurips23.streaming.diskann.diskann-str', '--constructor', 'diskann', '--runs', '5', '--count', '10', '--neurips23track', 'streaming', '--runbook_path', 'neurips23/streaming/final_runbook.yaml', '["euclidean", {"R": 50, "L": 50, "insert_threads": 16, "consolidate_threads": 16}]', '[{"Ls": 70, "T": 16}]']
> 2024-08-16 01:49:43,125 - annb.271fd74032af - INFO - ['euclidean', {'R': 50, 'L': 50, 'insert_threads': 16, 'consolidate_threads': 16}]
> 2024-08-16 01:49:43,125 - annb.271fd74032af - INFO - Trying to instantiate neurips23.streaming.diskann.diskann-str.diskann(['euclidean', {'R': 50, 'L': 50, 'insert_threads': 16, 'consolidate_threads': 16}])
> 2024-08-16 01:49:43,207 - annb.271fd74032af - INFO - Running diskann on msturing-30M-clustered
> 2024-08-16 01:49:43,876 - annb.271fd74032af - INFO - L2: Using AVX2 distance computation DistanceL2Float
> 2024-08-16 01:49:45,494 - annb.271fd74032af - INFO - Index class constructed and ready for update/search
> 2024-08-16 01:49:45,494 - annb.271fd74032af - INFO - Algorithm set up
> 2024-08-16 01:49:45,495 - annb.271fd74032af - INFO - Built index in 1.6947686672210693
> 2024-08-16 01:49:45,495 - annb.271fd74032af - INFO - Index memory footprint:  4886620.0
> 2024-08-16 01:49:45,495 - annb.271fd74032af - INFO - Starting query
> 2024-08-16 01:49:45,495 - annb.271fd74032af - INFO - Running query argument group 1 of 1...
> 2024-08-16 01:49:45,495 - annb.271fd74032af - INFO - Got 10000 queries
> 2024-08-16 01:49:45,495 - annb.271fd74032af - INFO - Traceback (most recent call last):
> 2024-08-16 01:49:45,495 - annb.271fd74032af - INFO -   File "/home/app/run_algorithm.py", line 3, in <module>
> 2024-08-16 01:49:45,496 - annb.271fd74032af - INFO -     run_from_cmdline()
> 2024-08-16 01:49:45,496 - annb.271fd74032af - INFO -   File "/home/app/benchmark/runner.py", line 228, in run_from_cmdline
> 2024-08-16 01:49:45,496 - annb.271fd74032af - INFO -     run(definition, args.dataset, args.count, args.runs, args.rebuild,
> 2024-08-16 01:49:45,496 - annb.271fd74032af - INFO -   File "/home/app/benchmark/runner.py", line 103, in run
> 2024-08-16 01:49:45,496 - annb.271fd74032af - INFO -     descriptor, results = custom_runner.run_task(
> 2024-08-16 01:49:45,496 - annb.271fd74032af - INFO -   File "/home/app/neurips23/streaming/run.py", line 44, in run_task
> 2024-08-16 01:49:45,496 - annb.271fd74032af - INFO -     algo.insert(ds.get_data_in_range(start, end), ids)
> 2024-08-16 01:49:45,497 - annb.271fd74032af - INFO -   File "/home/app/benchmark/datasets.py", line 196, in get_data_in_range
> 2024-08-16 01:49:45,497 - annb.271fd74032af - INFO -     filename = self.get_dataset_fn()
> 2024-08-16 01:49:45,497 - annb.271fd74032af - INFO -   File "/home/app/benchmark/datasets.py", line 181, in get_dataset_fn
> 2024-08-16 01:49:45,497 - annb.271fd74032af - INFO -     raise RuntimeError("file %s not found" %fn)
> 2024-08-16 01:49:45,497 - annb.271fd74032af - INFO - RuntimeError: file data/MSTuring-30M-clustered/30M-clustered64.fbin not found
> 2024-08-16 01:49:46,559 - annb.271fd74032af - ERROR - ['euclidean', {'R': 50, 'L': 50, 'insert_threads': 16, 'consolidate_threads': 16}]
> Trying to instantiate neurips23.streaming.diskann.diskann-str.diskann(['euclidean', {'R': 50, 'L': 50, 'insert_threads': 16, 'consolidate_threads': 16}])
> Running diskann on msturing-30M-clustered
> L2: Using AVX2 distance computation DistanceL2Float
> Index class constructed and ready for update/search
> Algorithm set up
> Built index in 1.6947686672210693
> Index memory footprint:  4886620.0
> Starting query
> Running query argument group 1 of 1...
> Got 10000 queries
> Traceback (most recent call last):
>   File "/home/app/run_algorithm.py", line 3, in <module>
>     run_from_cmdline()
>   File "/home/app/benchmark/runner.py", line 228, in run_from_cmdline
>     run(definition, args.dataset, args.count, args.runs, args.rebuild,
>   File "/home/app/benchmark/runner.py", line 103, in run
>     descriptor, results = custom_runner.run_task(
>   File "/home/app/neurips23/streaming/run.py", line 44, in run_task
>     algo.insert(ds.get_data_in_range(start, end), ids)
>   File "/home/app/benchmark/datasets.py", line 196, in get_data_in_range
>     filename = self.get_dataset_fn()
>   File "/home/app/benchmark/datasets.py", line 181, in get_dataset_fn
>     raise RuntimeError("file %s not found" %fn)
> RuntimeError: file data/MSTuring-30M-clustered/30M-clustered64.fbin not found
> 
> 2024-08-16 01:49:46,560 - annb.271fd74032af - ERROR - Child process for container 271fd74032afreturned exit code 1 with message 
```

