### PR TITLE
Move filename generation outside if-else block in datasets.py

### DIFF
--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -153,6 +153,9 @@ class DatasetCompetitionFormat(Dataset):
         fn = self.ds_fn
         sourceurl = os.path.join(self.base_url, fn)
         outfile = os.path.join(self.basedir, fn)
+        if self.nb != original_size:
+            outfile = outfile + '.crop_nb_%d' % self.nb
+            
         if os.path.exists(outfile):
             print("file %s already exists" % outfile)
             return
@@ -164,7 +167,6 @@ class DatasetCompetitionFormat(Dataset):
         else:
             # download cropped version of file
             file_size = 8 + self.d * self.nb * np.dtype(self.dtype).itemsize
-            outfile = outfile + '.crop_nb_%d' % self.nb
             if os.path.exists(outfile):
                 print("file %s already exists" % outfile)
                 return


### PR DESCRIPTION
In `datasets.py`, when calling `prepare` on a slice of a dataset, the filename was incorrectly being set to the base dataset filename when checking whether the file already existed. This caused download of smaller slices to be skipped if the base dataset file already existed in the user's `data` directory. This PR changes the filename to the cropped filename *before* checking for existence and thus makes sure the cropped file is downloaded where applicable. 