### PR TITLE
Bubble up errors from a docker container

### DIFF
--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -39,6 +39,7 @@ def positive_int(s):
 
 def run_worker(args, queue):
     print("RW", args)
+    failures = []
     while not queue.empty():
         definition = queue.get()
         memory_margin = 500e6  # reserve some extra memory for misc stuff
@@ -46,21 +47,29 @@ def run_worker(args, queue):
         #mem_limit = 128e9 # 128gb for competition
         cpu_limit = "0-%d" % (multiprocessing.cpu_count() - 1)
 
-        if args.nodocker:
-            run_no_docker(definition, args.dataset, args.count,
-                          args.runs, args.timeout, args.rebuild, cpu_limit, mem_limit,
-                          args.t3, args.power_capture,
-                          args.upload_index, args.download_index,
-                          args.blob_prefix, args.sas_string,
-                          args.private_query, args.neurips23track, args.runbook_path)
+        try:
+            if args.nodocker:
+                run_no_docker(definition, args.dataset, args.count,
+                              args.runs, args.timeout, args.rebuild, cpu_limit, mem_limit,
+                              args.t3, args.power_capture,
+                              args.upload_index, args.download_index,
+                              args.blob_prefix, args.sas_string,
+                              args.private_query, args.neurips23track, args.runbook_path)
 
-        else:
-            run_docker(definition, args.dataset, args.count,
-                       args.runs, args.timeout, args.rebuild, cpu_limit, mem_limit,
-                       args.t3, args.power_capture,
-                       args.upload_index, args.download_index,
-                       args.blob_prefix, args.sas_string,
-                       args.private_query, args.neurips23track, args.runbook_path)
+            else:
+                run_docker(definition, args.dataset, args.count,
+                           args.runs, args.timeout, args.rebuild, cpu_limit, mem_limit,
+                           args.t3, args.power_capture,
+                           args.upload_index, args.download_index,
+                           args.blob_prefix, args.sas_string,
+                           args.private_query, args.neurips23track, args.runbook_path)
+        except Exception:
+            logging.error('Algorithm %s failed with exception' % definition.algorithm)
+            traceback.print_exc()
+            failures.append(definition.algorithm)
+
+    if failures:
+        raise RuntimeError('The following algorithms failed: %s' % ', '.join(failures))
 
 
 def main():
@@ -266,3 +275,6 @@ def main():
                for i in range(1)]
     [worker.start() for worker in workers]
     [worker.join() for worker in workers]
+
+    if any(worker.exitcode != 0 for worker in workers):
+        raise RuntimeError('One or more algorithm runs failed')

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -325,6 +325,7 @@ def run_docker(definition, dataset, count, runs, timeout, rebuild,
         logger.error('Container.wait for container %s failed with exception' % container.short_id)
         logger.error('Invoked with %s' % cmd)
         traceback.print_exc()
+        raise
     finally:
         container.remove(force=True)
 
@@ -342,6 +343,7 @@ def _handle_container_return_value(return_value, container, logger):
     if exit_code not in [0, None]:
         logger.error(colors.color(container.logs().decode(), fg='red'))
         logger.error(msg)
+        raise RuntimeError(msg)
 
 
 def run_no_docker(definition, dataset, count, runs, timeout, rebuild,


### PR DESCRIPTION
# Why
Errors inside the container were being swallowed, so callers had no visibility when a benchmark failed.

# What
This PR ensures that exceptions from the Docker container are propagated up to main.py.

- `/benchmark/runner.py`: Changed exception handling to re-raise errors instead of silently logging them, and added `RuntimeError` when container exit codes are non-zero
- `/benchmark/main.py`: Wrapped algorithm execution in try-except blocks to collect failures in a list and raise a `RuntimeError` with all failed algorithms at the end
- `/benchmark/main.py`: Added worker exit code validation in `main()` to raise `RuntimeError` if any worker process failed