### PR TITLE
Bubble up errors on Docker build failures in install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -100,3 +100,7 @@ if __name__ == "__main__":
         pool.join()
 
     print('\n\nInstall Status:\n' + '\n'.join(str(algo) for algo in install_status))
+
+    failures = [tag for result in install_status for tag, status in result.items() if status == 'fail']
+    if failures:
+        raise RuntimeError('The following Docker builds failed: %s' % ', '.join(failures))


### PR DESCRIPTION
 # Why

  Docker build failures in install.py were being logged but not surfaced as errors, so CI pipelines and callers had no
  way to detect when an algorithm failed to install.

 # What

  This PR ensures that Docker build failures are propagated as exceptions so callers have visibility into install
  failures.

   - `install.py`: Added failure collection that gathers all tags with a `fail` status and raises a RuntimeError 
  listing the failed Docker builds
