### PR TITLE
Fix YFCC image preparation for sampled 1M/10M header assertion

### DIFF
--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -700,8 +700,15 @@ class YFCCImagesDataset(DatasetCompetitionFormat):
         self.private_qs_url = None
         self.private_gt_url = None
 
-    def prepare(self, skip_data=False, original_size=98735605):
-        return super().prepare(skip_data, 98735605)
+    def prepare(self, skip_data=False, original_size=None):
+        if self.nb == 1000000:
+            original_size = 1000000
+        elif self.nb == 10000000:
+            original_size = 10000000
+        else:
+            original_size = 98735605
+
+        return super().prepare(skip_data, original_size)
 
     def get_dataset_fn(self):
         fn = os.path.join(self.basedir, self.ds_fn)


### PR DESCRIPTION
The YFCC image loader uses separate pre-sampled files for the 1M and 10M variants, but `prepare()` passed the full 98.7M dataset size as the expected source header. This made the generic cropping path assert when the downloaded sampled files already had headers matching their sampled sizes.

Use the sampled dataset size as the expected original size for the 1M and 10M variants, while preserving the full-size behavior for the 98.7M dataset.