### PR TITLE
Integrate Dino10B dataset into Big ANN Benchmarks

### DIFF
--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -16,7 +16,7 @@ from urllib.request import urlretrieve
 from .dataset_io import (
     xbin_mmap, download_accelerated, download, sanitize,
     knn_result_read, range_result_read, read_sparse_matrix,
-    write_sparse_matrix,
+    write_sparse_matrix, bvecs_mmap,
 )
 
 
@@ -1315,6 +1315,96 @@ class OpenAIEmbedding1M(DatasetCompetitionFormat):
         return f"{self.__class__.__name__}-{self.nb}"
 
 
+class DINO10BDataset(DatasetCompetitionFormat):
+    """
+    10 billion 1024-d uint8 vectors extracted from YFCC100M image patches
+    using a DINOv3 ViT-L/16 model (facebook/dinov3-vitl16-pretrain-lvd1689m).
+    Data is stored as chunked .bvecs files (50 chunks, 200M vectors each).
+    """
+
+    VECTORS_PER_CHUNK = 200_000_000
+
+    def __init__(self, nb_M=10000):
+        self.nb = nb_M * 10**6
+        self.d = 1024
+        self.nq = 100_000
+        self.dtype = "uint8"
+        self.basedir = os.path.join(BASEDIR, "dino_vitl_10B")
+        self.base_url = (
+            "http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B")
+        self.num_chunks = math.ceil(self.nb / self.VECTORS_PER_CHUNK)
+        self.gt_fn = "gts_bin/gts_dino_patch_%d_k10.bin" % self.nb
+        self.qs_fn = None
+        self.ds_fn = None
+        self.private_qs_url = None
+        self.private_gt_url = None
+
+    def prepare(self, skip_data=False):
+        if not os.path.exists(self.basedir):
+            os.makedirs(self.basedir)
+
+        qs_path = os.path.join(self.basedir, "queries_clean.bvecs")
+        if not os.path.exists(qs_path):
+            download(self.base_url + "/queries_clean.bvecs", qs_path)
+
+        gt_dir = os.path.join(self.basedir, "gts_bin")
+        if not os.path.exists(gt_dir):
+            os.makedirs(gt_dir)
+        gt_fn = "gts_dino_patch_%d_k10.bin" % self.nb
+        gt_path = os.path.join(gt_dir, gt_fn)
+        if not os.path.exists(gt_path):
+            download(self.base_url + "/gts_bin/" + gt_fn, gt_path)
+
+        if skip_data:
+            return
+
+        chunk_dir = os.path.join(self.basedir, "chunked_base_10B")
+        if not os.path.exists(chunk_dir):
+            os.makedirs(chunk_dir)
+        for i in range(self.num_chunks):
+            chunk_fn = "chunk_%04d.bvecs" % i
+            chunk_path = os.path.join(chunk_dir, chunk_fn)
+            if not os.path.exists(chunk_path):
+                download_accelerated(
+                    self.base_url + "/chunked_base_10B/" + chunk_fn,
+                    chunk_path)
+
+    def get_queries(self):
+        qs_path = os.path.join(self.basedir, "queries_clean.bvecs")
+        return sanitize(bvecs_mmap(qs_path)[:self.nq])
+
+    def get_dataset_iterator(self, bs=512, split=(1, 0)):
+        n_parts, part = split
+        part_start = (self.nb * part) // n_parts
+        part_end = (self.nb * (part + 1)) // n_parts
+
+        chunk_dir = os.path.join(self.basedir, "chunked_base_10B")
+        global_offset = 0
+        for i in range(self.num_chunks):
+            chunk_path = os.path.join(chunk_dir, "chunk_%04d.bvecs" % i)
+            chunk_data = bvecs_mmap(chunk_path)
+            n_in_chunk = chunk_data.shape[0]
+            chunk_end = global_offset + n_in_chunk
+
+            if chunk_end <= part_start:
+                global_offset = chunk_end
+                continue
+            if global_offset >= part_end:
+                break
+
+            lo = max(0, part_start - global_offset)
+            hi = min(n_in_chunk, part_end - global_offset)
+
+            for start in range(lo, hi, bs):
+                end = min(start + bs, hi)
+                yield sanitize(chunk_data[start:end])
+
+            global_offset = chunk_end
+
+    def distance(self):
+        return "euclidean"
+
+
 
 DATASETS = {
     'bigann-1B': lambda : BigANNDataset(1000),
@@ -1384,4 +1474,9 @@ DATASETS = {
     'random-filter-s': lambda : RandomFilterDS(100000, 1000, 50),
 
     'openai-embedding-1M': lambda: OpenAIEmbedding1M(93652),
+
+    'dino-10B': lambda: DINO10BDataset(10000),
+    'dino-1B': lambda: DINO10BDataset(1000),
+    'dino-100M': lambda: DINO10BDataset(100),
+    'dino-10M': lambda: DINO10BDataset(10),
 }

--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -1333,7 +1333,7 @@ class DINO10BDataset(DatasetCompetitionFormat):
         self.base_url = (
             "http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B")
         self.num_chunks = math.ceil(self.nb / self.VECTORS_PER_CHUNK)
-        self.gt_fn = "gts_bin/gts_dino_patch_%d_k10.bin" % self.nb
+        self.gt_fn = "gts_dino_patch_%d_k10.bin" % self.nb
         self.qs_fn = None
         self.ds_fn = None
         self.private_qs_url = None
@@ -1347,11 +1347,8 @@ class DINO10BDataset(DatasetCompetitionFormat):
         if not os.path.exists(qs_path):
             download(self.base_url + "/queries_clean.bvecs", qs_path)
 
-        gt_dir = os.path.join(self.basedir, "gts_bin")
-        if not os.path.exists(gt_dir):
-            os.makedirs(gt_dir)
         gt_fn = "gts_dino_patch_%d_k10.bin" % self.nb
-        gt_path = os.path.join(gt_dir, gt_fn)
+        gt_path = os.path.join(self.basedir, gt_fn)
         if not os.path.exists(gt_path):
             download(self.base_url + "/gts_bin/" + gt_fn, gt_path)
 

--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -1476,4 +1476,5 @@ DATASETS = {
     'dino-1B': lambda: DINO10BDataset(1000),
     'dino-100M': lambda: DINO10BDataset(100),
     'dino-10M': lambda: DINO10BDataset(10),
+    'dino-1M': lambda: DINO10BDataset(1),
 }

--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -1331,7 +1331,7 @@ class DINO10BDataset(BillionScaleDatasetCompetitionFormat):
     download accelerator. Every smaller size downloads only the first N
     vectors of the 1B file (a cropped prefix, with the header count rewritten)
     so that researchers on small machines never have to fetch the whole file.
-    Queries are shared across sizes; ground truth (top-10) is pre-computed per
+    Queries are shared across sizes; ground truth (top-100) is pre-computed per
     size.
 
     This is a BillionScaleDatasetCompetitionFormat, so the standard runner can
@@ -1367,7 +1367,7 @@ class DINO10BDataset(BillionScaleDatasetCompetitionFormat):
         self.ds_fn = ("dino_vitl_2B_base.u8bin" if self.nb == self.FULL_2B
                       else "dino_vitl_1B_base.u8bin")
         self.qs_fn = "queries_clean.bvecs"
-        self.gt_fn = "gts_dino_patch_%d_k10.bin" % self.nb
+        self.gt_fn = "gts_dino_patch_%d_k100.bin" % self.nb
         self.private_nq = 0
         self.private_qs_url = None
         self.private_gt_url = None

--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -1315,88 +1315,140 @@ class OpenAIEmbedding1M(DatasetCompetitionFormat):
         return f"{self.__class__.__name__}-{self.nb}"
 
 
-class DINO10BDataset(DatasetCompetitionFormat):
+class DINO10BDataset(BillionScaleDatasetCompetitionFormat):
     """
-    10 billion 1024-d uint8 vectors extracted from YFCC100M image patches
-    using a DINOv3 ViT-L/16 model (facebook/dinov3-vitl16-pretrain-lvd1689m).
-    Data is stored as chunked .bvecs files (50 chunks, 200M vectors each).
+    Dense vector benchmark of 1024-d uint8 vectors extracted from YFCC100M
+    image patches using a DINOv3 ViT-L/16 model
+    (facebook/dinov3-vitl16-pretrain-lvd1689m). The full corpus has 10B
+    vectors; this class exposes subsets of up to 2B vectors -- the largest
+    size whose vector count still fits the uint32 header of the .u8bin
+    competition format (max ~4.29B).
+
+    Two base files are published on the Meta public CDN:
+      * dino_vitl_1B_base.u8bin  -- the first 1,000,000,000 vectors
+      * dino_vitl_2B_base.u8bin  -- the first 2,000,000,000 vectors
+    A size of exactly 1B or 2B downloads the matching full file with the
+    download accelerator. Every smaller size downloads only the first N
+    vectors of the 1B file (a cropped prefix, with the header count rewritten)
+    so that researchers on small machines never have to fetch the whole file.
+    Queries are shared across sizes; ground truth (top-10) is pre-computed per
+    size.
+
+    This is a BillionScaleDatasetCompetitionFormat, so the standard runner can
+    locate the base file (``ds_fn``/``get_dataset_fn``), stream it
+    (``get_dataset_iterator``), and read queries/ground truth like any other
+    competition dataset.
     """
 
-    VECTORS_PER_CHUNK = 200_000_000
+    FULL_1B = 10**9
+    FULL_2B = 2 * 10**9
 
-    def __init__(self, nb_M=10000):
-        self.nb = nb_M * 10**6
+    def __init__(self, nb_M=1000):
+        self.nb_M = nb_M
+        # nb_M is in millions; it may be fractional for the sub-million sizes
+        # (e.g. 0.1 -> 100K), so round to an exact integer vector count.
+        self.nb = round(nb_M * 10**6)
+        assert 0 < self.nb <= self.FULL_2B, (
+            "DINO supports sizes up to 2B vectors; got nb=%d" % self.nb)
+        # Only the 1B and 2B files are published, so a size is buildable only
+        # if it is <= 1B (a prefix of the 1B file) or exactly 2B. A size
+        # strictly between 1B and 2B cannot be cropped from the 1B file.
+        assert self.nb <= self.FULL_1B or self.nb == self.FULL_2B, (
+            "DINO sizes between 1B and 2B are not buildable (no source file); "
+            "use a size <= 1B or exactly 2B; got nb=%d" % self.nb)
         self.d = 1024
         self.nq = 100_000
         self.dtype = "uint8"
         self.basedir = os.path.join(BASEDIR, "dino_vitl_10B")
         self.base_url = (
-            "http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B")
-        self.num_chunks = math.ceil(self.nb / self.VECTORS_PER_CHUNK)
+            "http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/")
+        # Base vectors: 2B has its own file; every size <= 1B is a prefix of
+        # the 1B file (downloaded whole at exactly 1B, cropped below 1B).
+        self.ds_fn = ("dino_vitl_2B_base.u8bin" if self.nb == self.FULL_2B
+                      else "dino_vitl_1B_base.u8bin")
+        self.qs_fn = "queries_clean.bvecs"
         self.gt_fn = "gts_dino_patch_%d_k10.bin" % self.nb
-        self.qs_fn = None
-        self.ds_fn = None
+        self.private_nq = 0
         self.private_qs_url = None
         self.private_gt_url = None
+
+    def _uses_full_file(self):
+        """True when nb maps to a complete published file (no cropping)."""
+        return self.nb in (self.FULL_1B, self.FULL_2B)
+
+    def _local_data_path(self):
+        """Local path of the (possibly cropped) base file, no existence check."""
+        fn = os.path.join(self.basedir, self.ds_fn)
+        if not self._uses_full_file():
+            fn += '.crop_nb_%d' % self.nb
+        return fn
+
+    def get_dataset_fn(self):
+        fn = self._local_data_path()
+        if os.path.exists(fn):
+            return fn
+        raise RuntimeError("file %s not found" % fn)
 
     def prepare(self, skip_data=False):
         if not os.path.exists(self.basedir):
             os.makedirs(self.basedir)
 
-        qs_path = os.path.join(self.basedir, "queries_clean.bvecs")
+        # Small files first: shared queries (bvecs) and per-size ground truth.
+        qs_path = os.path.join(self.basedir, self.qs_fn)
         if not os.path.exists(qs_path):
-            download(self.base_url + "/queries_clean.bvecs", qs_path)
+            download(self.base_url + self.qs_fn, qs_path)
 
-        gt_fn = "gts_dino_patch_%d_k10.bin" % self.nb
-        gt_path = os.path.join(self.basedir, gt_fn)
+        gt_path = os.path.join(self.basedir, self.gt_fn)
         if not os.path.exists(gt_path):
-            download(self.base_url + "/gts_bin/" + gt_fn, gt_path)
+            download(self.base_url + "gts_bin/" + self.gt_fn, gt_path)
 
         if skip_data:
             return
 
-        chunk_dir = os.path.join(self.basedir, "chunked_base_10B")
-        if not os.path.exists(chunk_dir):
-            os.makedirs(chunk_dir)
-        for i in range(self.num_chunks):
-            chunk_fn = "chunk_%04d.bvecs" % i
-            chunk_path = os.path.join(chunk_dir, chunk_fn)
-            if not os.path.exists(chunk_path):
-                download_accelerated(
-                    self.base_url + "/chunked_base_10B/" + chunk_fn,
-                    chunk_path)
+        outfile = self._local_data_path()
+        if os.path.exists(outfile):
+            print("file %s already exists" % outfile)
+            return
+
+        sourceurl = self.base_url + self.ds_fn
+        if self._uses_full_file():
+            # Exactly 1B or 2B: fetch the whole published file.
+            download_accelerated(sourceurl, outfile)
+        else:
+            # Smaller size: download only the first nb vectors of the 1B file
+            # (8-byte header + nb*d bytes), then rewrite the header count so
+            # the prefix is itself a valid .u8bin file. Build into a temp file
+            # and rename atomically, so an interrupted download never leaves a
+            # half-written file in place of the real one.
+            file_size = 8 + self.d * self.nb * np.dtype(self.dtype).itemsize
+            tmp = outfile + ".tmp"
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            download(sourceurl, tmp, max_size=file_size)
+            actual = os.path.getsize(tmp)
+            assert actual == file_size, (
+                "cropped download is %d bytes, expected %d (source smaller "
+                "than requested?)" % (actual, file_size))
+            header = np.memmap(tmp, shape=2, dtype='uint32', mode='r+')
+            assert header[0] == self.FULL_1B, (
+                "unexpected source vector count %d (expected %d)"
+                % (header[0], self.FULL_1B))
+            assert header[1] == self.d, (
+                "unexpected source dimension %d (expected %d)"
+                % (header[1], self.d))
+            header[0] = self.nb
+            header.flush()
+            del header
+            os.replace(tmp, outfile)
 
     def get_queries(self):
-        qs_path = os.path.join(self.basedir, "queries_clean.bvecs")
-        return sanitize(bvecs_mmap(qs_path)[:self.nq])
-
-    def get_dataset_iterator(self, bs=512, split=(1, 0)):
-        n_parts, part = split
-        part_start = (self.nb * part) // n_parts
-        part_end = (self.nb * (part + 1)) // n_parts
-
-        chunk_dir = os.path.join(self.basedir, "chunked_base_10B")
-        global_offset = 0
-        for i in range(self.num_chunks):
-            chunk_path = os.path.join(chunk_dir, "chunk_%04d.bvecs" % i)
-            chunk_data = bvecs_mmap(chunk_path)
-            n_in_chunk = chunk_data.shape[0]
-            chunk_end = global_offset + n_in_chunk
-
-            if chunk_end <= part_start:
-                global_offset = chunk_end
-                continue
-            if global_offset >= part_end:
-                break
-
-            lo = max(0, part_start - global_offset)
-            hi = min(n_in_chunk, part_end - global_offset)
-
-            for start in range(lo, hi, bs):
-                end = min(start + bs, hi)
-                yield sanitize(chunk_data[start:end])
-
-            global_offset = chunk_end
+        # Queries are stored in .bvecs (per-vector dim prefix), unlike the
+        # .u8bin base file, so override the generic xbin reader.
+        qs_path = os.path.join(self.basedir, self.qs_fn)
+        q = bvecs_mmap(qs_path)[:self.nq]
+        assert q.shape == (self.nq, self.d), (
+            "queries shape %s != (%d, %d)" % (q.shape, self.nq, self.d))
+        return sanitize(q)
 
     def distance(self):
         return "euclidean"
@@ -1472,9 +1524,17 @@ DATASETS = {
 
     'openai-embedding-1M': lambda: OpenAIEmbedding1M(93652),
 
-    'dino-10B': lambda: DINO10BDataset(10000),
+    'dino-2B': lambda: DINO10BDataset(2000),
     'dino-1B': lambda: DINO10BDataset(1000),
+    'dino-500M': lambda: DINO10BDataset(500),
+    'dino-200M': lambda: DINO10BDataset(200),
     'dino-100M': lambda: DINO10BDataset(100),
+    'dino-50M': lambda: DINO10BDataset(50),
+    'dino-20M': lambda: DINO10BDataset(20),
     'dino-10M': lambda: DINO10BDataset(10),
+    'dino-5M': lambda: DINO10BDataset(5),
     'dino-1M': lambda: DINO10BDataset(1),
+    'dino-500K': lambda: DINO10BDataset(0.5),
+    'dino-200K': lambda: DINO10BDataset(0.2),
+    'dino-100K': lambda: DINO10BDataset(0.1),
 }

--- a/dataset_preparation/dino10b_dataset.md
+++ b/dataset_preparation/dino10b_dataset.md
@@ -1,20 +1,30 @@
-# DINO 10B Dataset
+# DINO Dataset
 
-This file describes a public vector benchmark consisting of 10 billion 1024-dimensional uint8 vectors extracted from image patches in the [YFCC100M dataset](https://multimediacommons.wordpress.com/yfcc100m-core-dataset/) using a [DINOv3 ViT-L/16 model](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m).
+This file describes a public dense-vector benchmark of 1024-dimensional `uint8`
+vectors extracted from image patches in the
+[YFCC100M dataset](https://multimediacommons.wordpress.com/yfcc100m-core-dataset/)
+using a [DINOv3 ViT-L/16 model](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m).
 
-The dataset is one of the largest publicly available dense vector benchmarks, designed for evaluating approximate nearest neighbor search at extreme scale.
+The full corpus contains 10 billion vectors, making it one of the largest
+publicly available dense-vector benchmarks for approximate nearest neighbor
+search. Within this framework we expose **subsets of up to 2 billion vectors**
+(`dino-1M` … `dino-2B`). 2B is the largest size whose vector count still fits
+the 32-bit header of the competition `.u8bin` format (max ≈ 4.29B).
 
 
 ## License
 
-The original YFCC100M images are licensed under various [Creative Commons Licenses](http://www.creativecommons.org/) (see the metadata for each image). The embedding vectors and auxiliary files are released by Meta.
+The original YFCC100M images are licensed under various
+[Creative Commons Licenses](http://www.creativecommons.org/) (see the metadata
+for each image). The embedding vectors and auxiliary files are released by Meta
+under the [Creative Commons Attribution-NonCommercial 4.0 (CC BY-NC) license](https://creativecommons.org/licenses/by-nc/4.0/).
 
 
 ## Dataset Properties
 
 | Property | Value |
 |----------|-------|
-| Base vectors | 10,000,000,000 (10B) |
+| Base vectors | up to 2,000,000,000 (2B) in this framework (10B corpus available) |
 | Dimensions | 1024 |
 | Data type | uint8 |
 | Query vectors | 100,000 |
@@ -23,81 +33,94 @@ The original YFCC100M images are licensed under various [Creative Commons Licens
 | Ground truth | Top-10 nearest neighbors |
 
 
+## Using the dataset in this framework
+
+The dataset is registered in `benchmark/datasets.py` as `DINO10BDataset`
+(a subclass of `BillionScaleDatasetCompetitionFormat`). Prepare a size with:
+
+```bash
+python create_dataset.py --dataset dino-1M       # base + queries + ground truth
+python create_dataset.py --dataset dino-1M --skip-data   # queries + ground truth only
+```
+
+Registered sizes:
+
+| name | base vectors | source file | download |
+|------|--------------|-------------|----------|
+| `dino-100K` | 100,000       | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-200K` | 200,000       | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-500K` | 500,000       | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-1M`   | 1,000,000     | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-5M`   | 5,000,000     | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-10M`  | 10,000,000    | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-20M`  | 20,000,000    | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-50M`  | 50,000,000    | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-100M` | 100,000,000   | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-200M` | 200,000,000   | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-500M` | 500,000,000   | `dino_vitl_1B_base.u8bin` | first-N prefix (cropped) |
+| `dino-1B`   | 1,000,000,000 | `dino_vitl_1B_base.u8bin` | full file (accelerated) |
+| `dino-2B`   | 2,000,000,000 | `dino_vitl_2B_base.u8bin` | full file (accelerated) |
+
+For every size below 1B, only the **first N vectors** of the 1B file are
+downloaded (an 8-byte header plus `N × 1024` bytes), and the header's vector
+count is rewritten to N. This means a researcher on a small machine never has
+to fetch the whole 1B file — e.g. `dino-1M` downloads ~1 GB rather than ~1 TB.
+Sizes of exactly 1B or 2B download the corresponding complete file with the
+[Axel download accelerator](https://github.com/axel-download-accelerator/axel)
+(`axel`), so make sure it is on your `PATH` for those sizes.
+
+
 ## Files and Format
 
-The dataset uses the `.bvecs` binary format. In this format, each vector is stored as a 4-byte little-endian integer (the dimension), followed by `d` bytes of uint8 vector data. This per-vector header is repeated for every vector in the file.
+All files live under
+`http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/`.
 
-The base vectors are split across 50 chunk files (`chunk_0000.bvecs` through `chunk_0049.bvecs`), each containing 200 million vectors (~200GB per chunk). The total dataset size is approximately 10 TB.
+**Base vectors** use the competition `.u8bin` format: an 8-byte header of two
+little-endian `uint32` values (`n`, `d`), followed by `n × d` `uint8` bytes
+(row-major). The two published files are:
 
+```bash
+# 1B vectors  (header [1000000000, 1024]; ~1 TB)
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/dino_vitl_1B_base.u8bin
+# 2B vectors  (header [2000000000, 1024]; ~2 TB)
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/dino_vitl_2B_base.u8bin
+```
 
-### Download URLs
+**Queries** use the `.bvecs` format (each vector is a 4-byte little-endian
+`int32` dimension followed by `d` `uint8` bytes). There are 100,000 queries,
+shared across all sizes:
 
-**Queries and ground truth:**
 ```bash
 wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/queries_clean.bvecs
-wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts_bin/gts_dino_patch_10000000000_k10.bin
 ```
 
-**Base vectors (50 chunks):**
-```bash
-wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/chunked_base_10B/chunk_0000.bvecs
-wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/chunked_base_10B/chunk_0001.bvecs
-# ... through chunk_0049.bvecs
-```
+**Ground truth** is pre-computed per size (always the first N vectors of the
+corpus). Files use the standard competition KNN format: a header of two
+`uint32` values (`nq`, `k`), then `nq × k` `int32` neighbor indices, then
+`nq × k` `float32` L2 distances. Each file has 100,000 queries × 10 neighbors:
 
-
-### Accelerated Download
-
-Due to the large size of the data (~10 TB), we recommend using the [Axel download accelerator](https://github.com/axel-download-accelerator/axel):
-
-```bash
-wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/file_list.txt
-
-base_dir="data/dino_vitl_10B"
-mkdir -p "$base_dir/chunked_base_10B" "$base_dir/gts"
-
-while read -r url; do
-  path=$(echo "$url" | sed -E 's|https?://[^/]+/||')
-  rel=$(echo "$path" | cut -d/ -f3-)
-  [ -z "$rel" ] && rel=$(basename "$path")
-  out="$base_dir/$rel"
-  mkdir -p "$(dirname "$out")"
-  axel -n 16 -a -o "$out" "$url"
-done < file_list.txt
-rm file_list.txt
-```
-
-
-### Supported Subset Sizes
-
-Ground truth files are pre-computed for the following dataset sizes (always using the first N vectors from the chunked files):
-
-100K, 200K, 500K, 1M, 2M, 5M, 10M, 20M, 50M, 100M, 200M, 500M, 1B, 2B, 5B, 10B
-
-For smaller subsets, only the necessary chunk files need to be downloaded (each chunk contains 200M vectors).
-
-
-### Ground Truth Format
-
-Ground truth files are stored in the standard competition binary format: a header of two `uint32` values (`nq`, `k`), followed by `nq × k` `int32` nearest neighbor indices, followed by `nq × k` `float32` L2 distances. Each file contains 100,000 queries × 10 neighbors.
-
-Download URLs follow the pattern:
 ```bash
 wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts_bin/gts_dino_patch_{nb}_k10.bin
+# e.g. nb = 1000000, 200000000, 1000000000, 2000000000, ...
 ```
+
+Ground-truth files are available for: 100K, 200K, 500K, 1M, 5M, 10M, 20M, 50M,
+100M, 200M, 500M, 1B, and 2B.
 
 
 ## Development
 
 ### Embedding Generation
 
-Image patches from the YFCC100M dataset were processed through a DINOv3 ViT-L/16 model ([facebook/dinov3-vitl16-pretrain-lvd1689m](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m)). The resulting embeddings were quantized to uint8 and stored in chunked `.bvecs` format for efficient streaming access.
+Image patches from the YFCC100M dataset were processed through a DINOv3
+ViT-L/16 model
+([facebook/dinov3-vitl16-pretrain-lvd1689m](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m)).
+The resulting embeddings were quantized to `uint8` and stored in the `.u8bin`
+competition format.
 
 ### Training Set
 
-A training set ([`train_queries_99M.bvecs`](http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/train_queries_99M.bvecs), ~100GB) containing 99 million vectors is available for training quantizers or other index structures.
-
-### Notes
-
-- Each chunk file contains exactly 200 million vectors. When using a dataset size that is not a multiple of 200M, only a prefix of the last required chunk is used.
-- For large batch sizes, prefer batch sizes that are divisors of 200,000,000 to avoid splitting batches across chunk boundaries, which causes overhead from concatenation.
+A training set
+([`train_queries_99M.bvecs`](http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/train_queries_99M.bvecs),
+~100 GB) containing 99 million vectors is available for training quantizers or
+other index structures.

--- a/dataset_preparation/dino10b_dataset.md
+++ b/dataset_preparation/dino10b_dataset.md
@@ -1,0 +1,105 @@
+# DINO 10B Dataset
+
+This file describes a public vector benchmark consisting of 10 billion 1024-dimensional uint8 vectors extracted from image patches in the [YFCC100M dataset](https://multimediacommons.wordpress.com/yfcc100m-core-dataset/) using a [DINOv3 ViT-L/16 model](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m).
+
+The dataset is one of the largest publicly available dense vector benchmarks, designed for evaluating approximate nearest neighbor search at extreme scale.
+
+
+## License
+
+The original YFCC100M images are licensed under various [Creative Commons Licenses](http://www.creativecommons.org/) (see the metadata for each image). The embedding vectors and auxiliary files are released by Meta.
+
+
+## Dataset Properties
+
+| Property | Value |
+|----------|-------|
+| Base vectors | 10,000,000,000 (10B) |
+| Dimensions | 1024 |
+| Data type | uint8 |
+| Query vectors | 100,000 |
+| Training vectors | 99,000,000 |
+| Distance metric | L2 (Euclidean) |
+| Ground truth | Top-10 nearest neighbors |
+
+
+## Files and Format
+
+The dataset uses the `.bvecs` binary format. In this format, each vector is stored as a 4-byte little-endian integer (the dimension), followed by `d` bytes of uint8 vector data. This per-vector header is repeated for every vector in the file.
+
+The base vectors are split across 50 chunk files (`chunk_0000.bvecs` through `chunk_0049.bvecs`), each containing 200 million vectors (~200GB per chunk). The total dataset size is approximately 10 TB.
+
+
+### Download URLs
+
+**Queries and ground truth:**
+```bash
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/queries_clean.bvecs
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts/gts_dino_patch_10000000000_k10.npy
+```
+
+**Base vectors (50 chunks):**
+```bash
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/chunked_base_10B/chunk_0000.bvecs
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/chunked_base_10B/chunk_0001.bvecs
+# ... through chunk_0049.bvecs
+```
+
+A complete file list is available at:
+```bash
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/file_list.txt
+```
+
+
+### Accelerated Download
+
+Due to the large size of the data (~10 TB), we recommend using the [Axel download accelerator](https://github.com/axel-download-accelerator/axel):
+
+```bash
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/file_list.txt
+
+base_dir="data/dino_vitl_10B"
+mkdir -p "$base_dir/chunked_base_10B" "$base_dir/gts"
+
+while read -r url; do
+  path=$(echo "$url" | sed -E 's|https?://[^/]+/||')
+  rel=$(echo "$path" | cut -d/ -f3-)
+  [ -z "$rel" ] && rel=$(basename "$path")
+  out="$base_dir/$rel"
+  mkdir -p "$(dirname "$out")"
+  axel -n 16 -a -o "$out" "$url"
+done < file_list.txt
+rm file_list.txt
+```
+
+
+### Supported Subset Sizes
+
+Ground truth files are pre-computed for the following dataset sizes (always using the first N vectors from the chunked files):
+
+100K, 200K, 500K, 1M, 2M, 5M, 10M, 20M, 50M, 100M, 200M, 500M, 1B, 2B, 5B, 10B
+
+For smaller subsets, only the necessary chunk files need to be downloaded (each chunk contains 200M vectors).
+
+
+### Ground Truth Format
+
+Ground truth files are stored in the standard competition binary format: a header of two `uint32` values (`nq`, `k`), followed by `nq × k` `int32` nearest neighbor indices, followed by `nq × k` `float32` L2 distances. Each file contains 100,000 queries × 10 neighbors.
+
+Download URLs follow the pattern:
+```bash
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts_bin/gts_dino_patch_{nb}_k10.bin
+```
+
+
+## Development
+
+### Embedding Generation
+
+Image patches from the YFCC100M dataset were processed through a DINOv3 ViT-L/16 model ([facebook/dinov3-vitl16-pretrain-lvd1689m](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m)). The resulting embeddings were quantized to uint8 and stored in chunked `.bvecs` format for efficient streaming access.
+
+### Notes
+
+- Each chunk file contains exactly 200 million vectors. When using a dataset size that is not a multiple of 200M, only a prefix of the last required chunk is used.
+- For large batch sizes, prefer batch sizes that are divisors of 200,000,000 to avoid splitting batches across chunk boundaries, which causes overhead from concatenation.
+- The training set (`train_queries_99M.bvecs`, ~400GB) contains 99 million vectors and is available for training quantizers or other index structures.

--- a/dataset_preparation/dino10b_dataset.md
+++ b/dataset_preparation/dino10b_dataset.md
@@ -35,7 +35,7 @@ The base vectors are split across 50 chunk files (`chunk_0000.bvecs` through `ch
 **Queries and ground truth:**
 ```bash
 wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/queries_clean.bvecs
-wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts/gts_dino_patch_10000000000_k10.npy
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts_bin/gts_dino_patch_10000000000_k10.bin
 ```
 
 **Base vectors (50 chunks):**
@@ -43,11 +43,6 @@ wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts/gts_dino_patc
 wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/chunked_base_10B/chunk_0000.bvecs
 wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/chunked_base_10B/chunk_0001.bvecs
 # ... through chunk_0049.bvecs
-```
-
-A complete file list is available at:
-```bash
-wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/file_list.txt
 ```
 
 
@@ -98,8 +93,11 @@ wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts_bin/gts_dino_
 
 Image patches from the YFCC100M dataset were processed through a DINOv3 ViT-L/16 model ([facebook/dinov3-vitl16-pretrain-lvd1689m](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m)). The resulting embeddings were quantized to uint8 and stored in chunked `.bvecs` format for efficient streaming access.
 
+### Training Set
+
+A training set ([`train_queries_99M.bvecs`](http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/train_queries_99M.bvecs), ~100GB) containing 99 million vectors is available for training quantizers or other index structures.
+
 ### Notes
 
 - Each chunk file contains exactly 200 million vectors. When using a dataset size that is not a multiple of 200M, only a prefix of the last required chunk is used.
 - For large batch sizes, prefer batch sizes that are divisors of 200,000,000 to avoid splitting batches across chunk boundaries, which causes overhead from concatenation.
-- The training set (`train_queries_99M.bvecs`, ~400GB) contains 99 million vectors and is available for training quantizers or other index structures.

--- a/dataset_preparation/dino10b_dataset.md
+++ b/dataset_preparation/dino10b_dataset.md
@@ -30,7 +30,7 @@ under the [Creative Commons Attribution-NonCommercial 4.0 (CC BY-NC) license](ht
 | Query vectors | 100,000 |
 | Training vectors | 99,000,000 |
 | Distance metric | L2 (Euclidean) |
-| Ground truth | Top-10 nearest neighbors |
+| Ground truth | Top-100 nearest neighbors |
 
 
 ## Using the dataset in this framework
@@ -70,6 +70,28 @@ Sizes of exactly 1B or 2B download the corresponding complete file with the
 (`axel`), so make sure it is on your `PATH` for those sizes.
 
 
+## Sizes beyond 2B (5B and 10B)
+
+This framework intentionally stops at **2B**. The competition ground-truth format
+stores neighbor indices as `int32`, whose maximum value (≈ 2.147B) cannot address a
+5B or 10B database, and the `.u8bin` base header is a single `uint32` (max ≈ 4.29B).
+So the 5B and 10B subsets cannot be represented in the competition `.bin`/`.u8bin`
+files, and no loader is provided for them here (the `gts_bin/` `.bin` ground truth is
+published only for sizes ≤ 2B).
+
+The **full 10B corpus is still available** and can be used directly through the
+[faiss](https://github.com/facebookresearch/faiss) library, whose dataset class reads
+the chunked base and `int64` ground truth, so 5B/10B neighbor IDs are represented
+correctly:
+
+- faiss `contrib/datasets.py` → `DatasetDINO10B` (supports 100K … 10B).
+
+It streams the base from the chunked `.bvecs` files under
+`dino_vitl_10B/chunked_base_10B/chunk_*.bvecs` and reads ground truth from the `int64`
+`.npy` files under `dino_vitl_10B/gts/gts_dino_patch_<nb>_k10.npy` (rather than the
+`gts_bin/` `.bin` files this framework uses). Ground truth on that path is top-10 (k ≤ 10).
+
+
 ## Files and Format
 
 All files live under
@@ -97,10 +119,10 @@ wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/queries_clean.bve
 **Ground truth** is pre-computed per size (always the first N vectors of the
 corpus). Files use the standard competition KNN format: a header of two
 `uint32` values (`nq`, `k`), then `nq × k` `int32` neighbor indices, then
-`nq × k` `float32` L2 distances. Each file has 100,000 queries × 10 neighbors:
+`nq × k` `float32` (squared) L2 distances. Each file has 100,000 queries × 100 neighbors:
 
 ```bash
-wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts_bin/gts_dino_patch_{nb}_k10.bin
+wget http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/gts_bin/gts_dino_patch_{nb}_k100.bin
 # e.g. nb = 1000000, 200000000, 1000000000, 2000000000, ...
 ```
 


### PR DESCRIPTION
Adds the DINO 10B dataset — 10 billion 1024-d uint8 vectors from YFCC100M image patches, embedded with DINOv3 ViT-L/16.

Data hosted at http://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/

- `DINO10BDataset` class inheriting from `DatasetCompetitionFormat`
- 5 registered sizes: 1M, 10M, 100M, 1B, 10B
- Chunked .bvecs base vectors (50 × 200M), competition .bin ground truth
- Ground truth files available for 16 sizes (100K to 10B), additional sizes can be registered
- Dataset documentation in `dataset_preparation/dino10b_dataset.md`