### PR TITLE
Reorganize Caselaw, add filtered datasets for YFCC

### DIFF
--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -668,6 +668,50 @@ class OpenAIArXivDataset(DatasetCompetitionFormat):
 
 
 '''
+See `dataset_preparation/caselaw_dataset.md' for details of this dataset, including
+additional multi-vector and filter options
+'''
+class CaselawDataset(BillionScaleDatasetCompetitionFormat):
+    def __init__(self, nb=7414023):
+        self.nb = nb
+        self.d = 1536
+        self.nq = 89812
+        self.dtype = "float32"
+        self.ds_fn = "caselaw_base_embeddings.bin"
+        self.qs_fn = "caselaw_query_embeddings.bin"
+        self.gt_fn = (
+            "caselaw_gt.bin" if self.nb == 7414023 else
+            "caselaw_gt_1M.bin" if self.nb == 1000000 else
+            "caselaw_gt_100K.bin" if self.nb == 100000 else
+            None
+        )
+        self.basedir = os.path.join(BASEDIR, "caselaw")
+        self.base_url = "https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/"
+
+        self.private_qs_url = None
+        self.private_gt_url = None
+
+    def prepare(self, skip_data=False, original_size=7414023):
+        return super().prepare(skip_data, 7414023)
+
+    def get_dataset_fn(self):
+        fn = os.path.join(self.basedir, self.ds_fn)
+        if self.nb != 7414023:
+            fn += '.crop_nb_%d' % self.nb
+        if os.path.exists(fn):
+            return fn
+        else:
+            raise RuntimeError("file %s not found" %fn)
+        
+    def get_dataset(self):
+        slice = next(self.get_dataset_iterator(bs=self.nb))
+        return sanitize(slice)
+
+    def distance(self):
+        return "euclidean"
+
+
+'''
 YFCCImages consists of 98,735,605 1280-dimensional CLIP embeddings (model = hf://laion/CLIP-ViT-bigG-14-laion2B-39B-b160k) 
 for images in the YFCC100M dataset, with additional 100K queries drawn from the same source.
 Not all images from the original dataset were successfully embedded, so the final dataset
@@ -1384,4 +1428,8 @@ DATASETS = {
     'random-filter-s': lambda : RandomFilterDS(100000, 1000, 50),
 
     'openai-embedding-1M': lambda: OpenAIEmbedding1M(93652),
+
+    'caselaw-7M': lambda: CaselawDataset(7414023),
+    'caselaw-1M': lambda: CaselawDataset(1000000),
+    'caselaw-100K': lambda: CaselawDataset(100000),
 }

--- a/dataset_preparation/caselaw_dataset.md
+++ b/dataset_preparation/caselaw_dataset.md
@@ -64,19 +64,55 @@ Python functions for reading the jsonl metadata files and checking whether a lin
 
 ### Single Vector Files
 
-For ease of use for those who wish to work with single-vector datasets instead of multi-vector datasets, we also release a utility for splitting the dataset and query set into those documents which were embedded into a single vector (due to being short enough to fit within the embedding context token maximum), versus those which were embedded to multi-vectors. Due to the Pareto-like distribution of the document lengths, this resulted in 7414023 base vectors and 89812 query vectors after withholding multi-vector documents. The utility for this conversion is found in `multi_vector_utils.py`. This utility was used to isolate the base and query documents, metadata, and filters that embedded to single vectors. We then computed both filtered and unfiltered groundtruth for the single-vector base and query sets, as well as 100K and 1M prefixes of the base set. Note that the groundtruth ids are re-indexed, so the id of a vector in the groundtruth below does not correspond to the same vector as in the groundtruth files above.
+For those who wish to work with single-vector datasets instead of multi-vector datasets, we also release in a separate file the embeddings for documents which were embedded into a single vector (due to being short enough to fit within the embedding context token maximum). Due to the Pareto-like distribution of the document lengths, this resulted in 7414023 base vectors and 89812 query vectors after withholding multi-vector documents. 
 
-The groundtruth can be downloaded using the following links:
+The single-vector dataset and query set, along with ground truth for the entire dataset and 1M and 100K prefixes, can be downloaded using the `create_dataset` utility alongside other single-vector datasets in this benchmark:
 
 ```bash
-wget https://comp21storage.z5.web.core.windows.net/caselaw/caselaw_singlevec_gt.bin
-wget https://comp21storage.z5.web.core.windows.net/caselaw/caselaw_singlevec_gt_1M.bin
-wget https://comp21storage.z5.web.core.windows.net/caselaw/caselaw_singlevec_gt_100K.bin
-
-wget https://comp21storage.z5.web.core.windows.net/caselaw/caselaw_singlevec_gt_filtered.bin
-wget https://comp21storage.z5.web.core.windows.net/caselaw/caselaw_singlevec_gt_filtered_1M.bin
-wget https://comp21storage.z5.web.core.windows.net/caselaw/caselaw_singlevec_gt_filtered_100K.bin
+python3.10 create_dataset.py --dataset caselaw-7M
+python3.10 create_dataset.py --dataset caselaw-1M
+python3.10 create_dataset.py --dataset caselaw-100K
 ```
+
+We also release filter metadata and filtered groundtruth for the single-vector dataset, which can be downloaded using the following commands:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/caselaw_base_metadata.jsonl
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/caselaw_query_filters.jsonl
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/caselaw_query_metadata.jsonl
+
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/caselaw_gt_filtered.bin
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/caselaw_gt_filtered_1M.bin
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/caselaw_gt_filtered_100K.bin
+```
+
+Furthermore, we release separate query, filter, and groundtruth files for those wishing to separate the query set by match rate (the percent of base dataset points which satisfy the query filter). We choose three match rate regimes and isolate 10000 queries fitting that regime from the base set. The regimes and download links are as follows:
+
+For match rate .005-.01:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/low/query.bin
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/low/GT.bin
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/low/query_filters.jsonl
+```
+
+For match rate .01-.1:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/medium/query.bin
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/medium/GT.bin
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/medium/query_filters.jsonl
+```
+
+For match rate .1-.5:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/high/query.bin
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/high/GT.bin
+wget https://comp21storage.z5.web.core.windows.net/caselaw/single_vector/high/query_filters.jsonl
+```
+
+
 
 ### Parquet Files
 
@@ -100,9 +136,9 @@ Each legal case was formatted as a JSON string encoding all its fields, with the
 
 Here we provide a brief summary of how we selected a filter query for each query. Each of the four nontrivial metadata fields (excluding the document ids from consideration) was converted to a predicate. For fields "court_full_name", "court_jurisdiction", and "court_type", the predicate is in the form of equality to the string value. For "date_filed", a date range around the date of filing was used. For dates prior to 1900, a twenty-year radius around the date filed was used. For dates between 1900-1950, a ten-year radius was used; for dates 1950-present, a four-year radius was used. 
 
-Each query was randomly assigned a single predicate with probability one-third or a logical AND of two predicates with probability two-thirds. For the purposes of this document, a date radius query was counted as a single predicate, even though it is technically encoded as an AND of two predicates (less than a particular date and greater than a particular date). For the single-predicate queries, one of the four fields was randomly chosen with a slight bias towards court name to help keep the average specificity low. For the double-predicate queries, the first field was randomly chosen, but since the name of a court implies its type and jurisdiction, if "court_name" was the first field selected we disallowed type and jurisdiction for the second field, and similarly if type or jurisdiction were selected as the first field, we disallowed name as the second field. 
+Each query was randomly assigned a single predicate with probability one-third or a logical AND of two predicates with probability two-thirds. For the purposes of this document, a date radius query was counted as a single predicate, even though it is technically encoded as an AND of two predicates (less than a particular date and greater than a particular date). For the single-predicate queries, one of the four fields was randomly chosen with a slight bias towards court name to help keep the average match rate low. For the double-predicate queries, the first field was randomly chosen, but since the name of a court implies its type and jurisdiction, if "court_name" was the first field selected we disallowed type and jurisdiction for the second field, and similarly if type or jurisdiction were selected as the first field, we disallowed name as the second field. 
 
-The average specificity (proportion of base points satisfying a given query) was about 4.5%, with maximum value 38% and minimum 0%. We did not disallow non-satisfiable queries as they are a phenomenon that can validly occur in filter scenarios, but they were empirically very rare.
+The average match rate (proportion of base points satisfying a given query) was about 4.5%, with maximum value 38% and minimum 0%. We did not disallow non-satisfiable queries as they are a phenomenon that can validly occur in filter scenarios, but they were empirically very rare.
 
 ### Notes
 

--- a/dataset_preparation/caselaw_dataset.md
+++ b/dataset_preparation/caselaw_dataset.md
@@ -64,7 +64,7 @@ Python functions for reading the jsonl metadata files and checking whether a lin
 
 ### Single Vector Files
 
-For those who wish to work with single-vector datasets instead of multi-vector datasets, we also release in a separate file the embeddings for documents which were embedded into a single vector (due to being short enough to fit within the embedding context token maximum). Due to the Pareto-like distribution of the document lengths, this resulted in 7414023 base vectors and 89812 query vectors after withholding multi-vector documents. 
+For those who wish to work with single-vector datasets instead of multi-vector datasets, we also release in a separate file the embeddings for documents which were embedded into a single vector (due to being short enough to fit within the embedding context token maximum). The multi-vectors are dropped from the file. Due to the Pareto-like distribution of the document lengths, this resulted in 7414023 base vectors and 89812 query vectors after withholding multi-vector documents. The documents can be mapped back to their vectors in the larger base set and/or underlying data using the unique "case_id" field, but the groundtruth is re-indexed from 0 to 7414022.
 
 The single-vector dataset and query set, along with ground truth for the entire dataset and 1M and 100K prefixes, can be downloaded using the `create_dataset` utility alongside other single-vector datasets in this benchmark:
 

--- a/dataset_preparation/yfcc_filtered_dataset.md
+++ b/dataset_preparation/yfcc_filtered_dataset.md
@@ -75,5 +75,7 @@ wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-medium/GT.bin
 wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-medium/GT_1M.bin
 ```
 
+The license of the original images used in this dataset is mix of [CC {BY, BY-SA, BY-ND, BY-NC, NY-NC-SA, BY-NC-ND}](https://code.flickr.net/2014/10/15/the-ins-and-outs-of-the-yahoo-flickr-100-million-creative-commons-dataset/). This additional processed metadata and groundtruth are released under the same license as the image they represent.
+
 
 

--- a/dataset_preparation/yfcc_filtered_dataset.md
+++ b/dataset_preparation/yfcc_filtered_dataset.md
@@ -1,0 +1,79 @@
+# YFCC Dataset Supplemental Filters and Groundtruth
+
+This document details the design and download instructions for a supplemental set of metadata filters and filtered groundtruth for the YFCC dataset of 10 million CLIP descriptors of images used in the NeurIPS'23 filtered search competition. While the competition dataset used labels describing the contents of the images, this set of metadata and filters is limited to four components: "year", "month", "camera", and "country." The filter predicates are a mix of equality on a single label and a logical AND of equality on two labels.
+
+The base and query vectors with non-filtered groundtruth can be downloaded using `create_dataset` utility in the main repository:
+
+```bash
+python3.10 create_dataset.py --dataset yfcc-10M
+```
+
+They can also be downloaded, along with a million-sized slice and groundtruth, from the following urls:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/yfcc/base.10M.u8bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/base.1M.u8bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/query.public.100K.u8bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/groundtruth.bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/groundtruth_1M.bin
+```
+
+The filter metadata, query filters, and filtered groundtruth can be downloaded from the following urls:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/yfcc/base.10M.jsonl
+wget https://comp21storage.z5.web.core.windows.net/yfcc/base.1M.jsonl
+wget https://comp21storage.z5.web.core.windows.net/yfcc/query.public.100K.jsonl
+wget https://comp21storage.z5.web.core.windows.net/yfcc/groundtruth_filtered.bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/groundtruth_filtered_1M.bin
+```
+
+For convenience, we have also produced five subsets of the query filters of size 10K, which are separated by both match rate and filter type (single predicate or AND of two predicates). The filter and query files for these subsets, along with groundtruth with respect to the 1M and 10M slices of YFCC, are found below.
+
+Single filters, match rate range .0001-.001:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-low/query_10k.u8bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-low/query_filters.jsonl
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-low/GT.bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-low/GT_1M.bin
+```
+
+Single filters, match rate range .005-.036:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-medium/query_10k.u8bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-medium/query_filters.jsonl
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-medium/GT.bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-medium/GT_1M.bin
+```
+
+Single filters, match rate range .11-.34:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-high/query_10k.u8bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-high/query_filters.jsonl
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-high/GT.bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/single-high/GT_1M.bin
+```
+
+Two filters, match rate range .0001-.001:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-low/query_10k.u8bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-low/query_filters.jsonl
+wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-low/GT.bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-low/GT_1M.bin
+```
+
+Two filters, match rate range .006-.05:
+
+```bash
+wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-medium/query_10k.u8bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-medium/query_filters.jsonl
+wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-medium/GT.bin
+wget https://comp21storage.z5.web.core.windows.net/yfcc/multiple-medium/GT_1M.bin
+```
+
+
+


### PR DESCRIPTION
This PR does the following things:

1. Re-organize some of the download links for the Caselaw dataset, reflected in its instruction file.
2. Change `datasets.py` to allow for download of the single-vector version of the caselaw dataset.
3. Add some subsets of the Caselaw query set, separated by match rate, and reflect these in the instruction file.
4. Add an instruction file for downloading some additional subsets and filtered datasets for the YFCC dataset.

