### PR TITLE
Add Bluety closed-source OOD and Filter leaderboard entries

### DIFF
--- a/neurips23/ongoing_leaderboard/filter/submissions/bluety_filter_closed_source/README.md
+++ b/neurips23/ongoing_leaderboard/filter/submissions/bluety_filter_closed_source/README.md
@@ -1,0 +1,7 @@
+# Bluety Filter closed-source submission
+
+This PR requests inclusion of Bluety Filter as a closed-source entry for the ongoing Big-ANN / NeurIPS 2023 Filter leaderboard.
+
+The implementation is closed source. A private reproducibility package is available to maintainers with the BigANN wrapper, config, offline installer, verification script, and closed-source Python wheel so the algorithm can be independently run on a competition-spec VM.
+
+Submitted result: 97823.5 QPS at recall@10 = 0.910264 on yfcc-10M.

--- a/neurips23/ongoing_leaderboard/filter/submissions/bluety_filter_closed_source/res_yfcc-10M.csv
+++ b/neurips23/ongoing_leaderboard/filter/submissions/bluety_filter_closed_source/res_yfcc-10M.csv
@@ -1,0 +1,2 @@
+algorithm,parameters,dataset,count,qps,distcomps,build,indexsize,mean_ssd_ios,mean_latency,track,recall/ap
+bluety-filter-closed,"Bluety Filter closed-source wheel, nlist256, verified high-recall operating point",yfcc-10M,10,97823.5,0.0,0.0,0.0,0,1.022248,filter,0.910264

--- a/neurips23/ongoing_leaderboard/filter/submissions/bluety_filter_closed_source/summary.json
+++ b/neurips23/ongoing_leaderboard/filter/submissions/bluety_filter_closed_source/summary.json
@@ -1,0 +1,20 @@
+{
+  "submission": "bluety_filter_closed_source",
+  "track": "filter",
+  "dataset": "yfcc-10M",
+  "algorithm": "bluety-filter-closed",
+  "closed_source": true,
+  "reproducibility_package": "private wheel package available to maintainers",
+  "metric": "QPS at recall@10 >= 0.90",
+  "best_verified_qps": 97823.5,
+  "recall_at_10": 0.910264,
+  "hardware": "Azure Standard D8lds v5 class, 8 vCPU / 16 GiB, Ubuntu 22.04, Python 3.10, x86_64",
+  "package_contents": [
+    "BigANN Filter wrapper",
+    "config.yaml",
+    "offline install.py",
+    "verify_install.py",
+    "closed-source Python wheel"
+  ],
+  "archive_sha256_private": "44191fb31528afd7901b693f610d041d5d9b7a70b917842b1aeca79fb095ad1f"
+}

--- a/neurips23/ongoing_leaderboard/filter/submissions/bluety_filter_closed_source/vm_evidence.txt
+++ b/neurips23/ongoing_leaderboard/filter/submissions/bluety_filter_closed_source/vm_evidence.txt
@@ -1,0 +1,15 @@
+Closed-source reproducibility package prepared for maintainers.
+
+Track: Filter
+Dataset: yfcc-10M
+Hardware: Azure Standard D8lds v5 class, 8 vCPU / 16 GiB
+Environment: Ubuntu 22.04 / Python 3.10 / x86_64
+Metric: max QPS with recall@10 >= 0.90
+
+Best archived verified operating point:
+QPS: 97823.5
+recall@10: 0.910264
+
+The private package contains the BigANN Filter wrapper, config, offline installer,
+verification script, and closed-source Python wheel. It intentionally excludes
+source code, optimization notes, and technical writeups.

--- a/neurips23/ongoing_leaderboard/ood/submissions/bluety_roargraph_ood_closed_source/README.md
+++ b/neurips23/ongoing_leaderboard/ood/submissions/bluety_roargraph_ood_closed_source/README.md
@@ -1,0 +1,7 @@
+# Bluety RoarGraph OOD closed-source submission
+
+This PR requests inclusion of Bluety RoarGraph OOD as a closed-source entry for the ongoing Big-ANN / NeurIPS 2023 OOD leaderboard.
+
+The implementation is closed source. A private reproducibility package is available to maintainers with the BigANN wrapper, config, offline installer, verification script, closed-source Python wheel, and evidence CSV so the algorithm can be independently run on a competition-spec VM.
+
+Submitted result: 47058.8 QPS at recall@10 = 0.900239 on text2image-10M.

--- a/neurips23/ongoing_leaderboard/ood/submissions/bluety_roargraph_ood_closed_source/res_text2image-10M.csv
+++ b/neurips23/ongoing_leaderboard/ood/submissions/bluety_roargraph_ood_closed_source/res_text2image-10M.csv
@@ -1,0 +1,2 @@
+algorithm,parameters,dataset,count,qps,distcomps,build,indexsize,mean_ssd_ios,mean_latency,track,recall/ap
+bluety-roargraph-ood-closed,"RoarGraph OOD closed-source wheel, cap42_pf4_pa10_rr20_es62_q2048_s4_L117, PGO build",text2image-10M,10,47058.8,0.0,2265.42,103059000.0,0,0.02125,ood,0.900239

--- a/neurips23/ongoing_leaderboard/ood/submissions/bluety_roargraph_ood_closed_source/summary.json
+++ b/neurips23/ongoing_leaderboard/ood/submissions/bluety_roargraph_ood_closed_source/summary.json
@@ -1,0 +1,22 @@
+{
+  "submission": "bluety_roargraph_ood_closed_source",
+  "track": "ood",
+  "dataset": "text2image-10M",
+  "algorithm": "bluety-roargraph-ood-closed",
+  "closed_source": true,
+  "reproducibility_package": "private wheel package available to maintainers",
+  "metric": "QPS at recall@10 >= 0.90",
+  "best_qps": 47058.8,
+  "recall_at_10": 0.900239,
+  "three_run_qps": [46992.5, 47036.7, 47058.8],
+  "hardware": "Azure Standard D8lds v5 class, 8 vCPU / 16 GiB, Ubuntu 22.04, Python 3.10, x86_64",
+  "package_contents": [
+    "BigANN OOD wrapper",
+    "config.yaml",
+    "offline install.py",
+    "verify_install.py",
+    "closed-source Python wheel",
+    "evidence CSV"
+  ],
+  "archive_sha256_private": "b1e4450f41eae5f28199862c70c977474e3f6a30f23efa9019a5f343377bce23"
+}

--- a/neurips23/ongoing_leaderboard/ood/submissions/bluety_roargraph_ood_closed_source/vm_evidence.txt
+++ b/neurips23/ongoing_leaderboard/ood/submissions/bluety_roargraph_ood_closed_source/vm_evidence.txt
@@ -1,0 +1,19 @@
+Closed-source reproducibility package prepared for maintainers.
+
+Track: OOD
+Dataset: text2image-10M
+Hardware: Azure Standard D8lds v5 class, 8 vCPU / 16 GiB
+Environment: Ubuntu 22.04 / Python 3.10 / x86_64
+Metric: max QPS with recall@10 >= 0.90
+
+Three-run evidence CSV:
+117,46992.5,2265.42,0.02128,0.900239,103.059
+117,47036.7,2265.42,0.02126,0.900239,103.059
+117,47058.8,2265.42,0.02125,0.900239,103.059
+
+Closed-source package archive SHA256:
+b1e4450f41eae5f28199862c70c977474e3f6a30f23efa9019a5f343377bce23  roargraph_ood_closed_submission.tar.gz
+
+The private package contains the BigANN OOD wrapper, config, offline installer,
+verification script, closed-source Python wheel, NumPy wheel, and evidence CSV.
+It intentionally excludes source code, optimization notes, and technical writeups.


### PR DESCRIPTION
This PR requests inclusion of two Bluety closed-source entries for the ongoing Big-ANN / NeurIPS 2023 leaderboards.

## OOD

Track: OOD  
Dataset: text2image-10M  
Hardware: Azure Standard D8lds v5 class, 8 vCPU / 16 GiB  
Metric: max QPS with recall@10 >= 0.9

Result:

- recall@10: 0.900239
- QPS: 47058.8
- three runs: 46992.5 / 47036.7 / 47058.8 QPS

## Filter

Track: Filter  
Dataset: yfcc-10M  
Hardware: Azure Standard D8lds v5 class, 8 vCPU / 16 GiB  
Metric: max QPS with recall@10 >= 0.9

Result:

- recall@10: 0.910264
- QPS: 97823.5

Both implementations are closed source. We have prepared private reproducibility packages for maintainers containing the BigANN wrapper, config, offline installer, verification script, closed-source Python wheel, and evidence files so the algorithms can be independently run on a competition-spec VM.

We will email the private packages to `big-ann-organizers@googlegroups.com` unless you prefer another private delivery method. The public files in this PR contain only leaderboard submission metadata and evidence, not the closed-source runtime wheels.